### PR TITLE
Add business and AI service modules with migration docs

### DIFF
--- a/MIGRATION_LOG.md
+++ b/MIGRATION_LOG.md
@@ -1,0 +1,18 @@
+
+## Day 8: $(date +%Y-%m-%d)
+
+- [x] Business API services
+- [x] AI Bible system
+- [x] Ollama local LLM
+- [x] Database infrastructure
+- [x] Business profile
+- [x] AI profile
+
+Services migrated: 15+ total
+Complex services now included:
+
+- AI Bible with auto-generation
+- Ollama with GPU support
+- PostgreSQL with backups
+- Redis cache
+- Business APIs

--- a/day8-business-ai.md
+++ b/day8-business-ai.md
@@ -1,0 +1,683 @@
+# Day 8: Business Services & AI Infrastructure (5-6 hours)
+
+## Morning Session (3 hours)
+### 9:00 AM - Business Services Migration ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 1: Create business API module
+cat > modules/services/business-api.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.businessApi;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.businessApi = {
+    enable = lib.mkEnableOption "Business API services";
+    
+    apis = {
+      invoicing = {
+        enable = lib.mkEnableOption "Invoicing API";
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3001;
+        };
+        database = lib.mkOption {
+          type = lib.types.str;
+          default = "postgresql://localhost/invoicing";
+        };
+      };
+      
+      crm = {
+        enable = lib.mkEnableOption "CRM API";
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3002;
+        };
+      };
+      
+      analytics = {
+        enable = lib.mkEnableOption "Analytics API";
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3003;
+        };
+      };
+    };
+    
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.state}/business";
+    };
+  };
+  
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    (lib.mkIf cfg.apis.invoicing.enable {
+      virtualisation.oci-containers.containers.invoicing-api = {
+        image = "business/invoicing:latest";
+        ports = [ "${toString cfg.apis.invoicing.port}:3000" ];
+        volumes = [
+          "${cfg.dataDir}/invoicing:/data"
+        ];
+        environment = {
+          DATABASE_URL = cfg.apis.invoicing.database;
+          NODE_ENV = "production";
+        };
+      };
+    })
+    
+    (lib.mkIf cfg.apis.crm.enable {
+      virtualisation.oci-containers.containers.crm-api = {
+        image = "business/crm:latest";
+        ports = [ "${toString cfg.apis.crm.port}:3000" ];
+        volumes = [
+          "${cfg.dataDir}/crm:/data"
+        ];
+      };
+    })
+    
+    {
+      systemd.tmpfiles.rules = [
+        "d ${cfg.dataDir} 0750 root root -"
+        "d ${cfg.dataDir}/invoicing 0750 root root -"
+        "d ${cfg.dataDir}/crm 0750 root root -"
+      ];
+      
+      networking.firewall.allowedTCPPorts = lib.flatten [
+        (lib.optional cfg.apis.invoicing.enable cfg.apis.invoicing.port)
+        (lib.optional cfg.apis.crm.enable cfg.apis.crm.port)
+      ];
+    }
+  ]);
+}
+EOF
+
+# Step 2: Create comprehensive AI/Bible system module
+cat > modules/services/ai-bible.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.aiBible;
+  paths = config.hwc.paths;
+  
+  # Python environment for AI services
+  pythonEnv = pkgs.python3.withPackages (ps: with ps; [
+    fastapi uvicorn pydantic
+    torch transformers
+    pandas numpy
+    pyyaml
+  ]);
+in {
+  options.hwc.services.aiBible = {
+    enable = lib.mkEnableOption "AI Bible documentation system";
+    
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8888;
+      description = "API port";
+    };
+    
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.state}/ai-bible";
+    };
+    
+    features = {
+      autoGeneration = lib.mkEnableOption "Auto documentation generation";
+      
+      llmIntegration = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable LLM integration";
+      };
+      
+      categories = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "system_architecture"
+          "container_services"
+          "hardware_gpu"
+          "monitoring_observability"
+          "storage_data"
+        ];
+        description = "Documentation categories";
+      };
+    };
+    
+    llm = {
+      provider = lib.mkOption {
+        type = lib.types.enum [ "ollama" "openai" "anthropic" ];
+        default = "ollama";
+      };
+      
+      model = lib.mkOption {
+        type = lib.types.str;
+        default = "llama2";
+        description = "LLM model to use";
+      };
+      
+      endpoint = lib.mkOption {
+        type = lib.types.str;
+        default = "http://localhost:11434";
+        description = "LLM API endpoint";
+      };
+    };
+  };
+  
+  config = lib.mkIf cfg.enable {
+    # Main AI Bible service
+    systemd.services.ai-bible = {
+      description = "AI Bible Documentation System";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ] ++ 
+        lib.optional (cfg.llm.provider == "ollama") "ollama.service";
+      
+      environment = {
+        BIBLE_PORT = toString cfg.port;
+        BIBLE_DATA = cfg.dataDir;
+        LLM_PROVIDER = cfg.llm.provider;
+        LLM_MODEL = cfg.llm.model;
+        LLM_ENDPOINT = cfg.llm.endpoint;
+      };
+      
+      serviceConfig = {
+        ExecStart = "${pythonEnv}/bin/python ${cfg.dataDir}/bible_system.py";
+        WorkingDirectory = cfg.dataDir;
+        Restart = "on-failure";
+        User = "ai-bible";
+        Group = "ai-bible";
+        
+        # Security
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir ];
+      };
+    };
+    
+    # Auto-generation timer
+    systemd.timers.ai-bible-generate = lib.mkIf cfg.features.autoGeneration {
+      description = "AI Bible auto-generation timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
+    };
+    
+    systemd.services.ai-bible-generate = lib.mkIf cfg.features.autoGeneration {
+      description = "Generate AI Bible documentation";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pythonEnv}/bin/python ${cfg.dataDir}/bible_rewriter.py";
+        User = "ai-bible";
+      };
+    };
+    
+    # Provision Bible system files
+    environment.etc = {
+      "ai-bible/config.yaml".text = lib.generators.toYAML {} {
+        categories = cfg.features.categories;
+        llm = {
+          provider = cfg.llm.provider;
+          model = cfg.llm.model;
+          endpoint = cfg.llm.endpoint;
+        };
+        features = {
+          auto_generation = cfg.features.autoGeneration;
+          llm_integration = cfg.features.llmIntegration;
+        };
+      };
+      
+      "ai-bible/prompts".source = ./modules/ai-bible/prompts;
+    };
+    
+    # User and permissions
+    users.users.ai-bible = {
+      isSystemUser = true;
+      group = "ai-bible";
+      home = cfg.dataDir;
+    };
+    users.groups.ai-bible = {};
+    
+    # Setup directories and copy Python scripts
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0750 ai-bible ai-bible -"
+      "d ${cfg.dataDir}/bibles 0750 ai-bible ai-bible -"
+      "d ${cfg.dataDir}/prompts 0750 ai-bible ai-bible -"
+      "d ${cfg.dataDir}/output 0750 ai-bible ai-bible -"
+    ];
+    
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}
+EOF
+
+# Step 3: Create Ollama module for local LLM
+cat > modules/services/ollama.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.ollama;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.ollama = {
+    enable = lib.mkEnableOption "Ollama local LLM";
+    
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 11434;
+      description = "API port";
+    };
+    
+    models = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "llama2" "codellama" ];
+      description = "Models to download";
+    };
+    
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.hot}/ollama";
+      description = "Model storage directory";
+    };
+    
+    enableGpu = lib.mkEnableOption "GPU acceleration";
+    
+    memoryLimit = lib.mkOption {
+      type = lib.types.str;
+      default = "16G";
+      description = "Memory limit";
+    };
+  };
+  
+  config = lib.mkIf cfg.enable {
+    virtualisation.oci-containers.containers.ollama = {
+      image = "ollama/ollama:latest";
+      
+      ports = [ "${toString cfg.port}:11434" ];
+      
+      volumes = [
+        "${cfg.dataDir}:/root/.ollama"
+      ];
+      
+      environment = {
+        OLLAMA_HOST = "0.0.0.0";
+        OLLAMA_MODELS = cfg.dataDir;
+      };
+      
+      extraOptions = lib.optionals cfg.enableGpu [
+        "--gpus=all"
+        "--device=/dev/nvidia0"
+        "--device=/dev/nvidiactl"
+        "--device=/dev/nvidia-uvm"
+      ];
+    };
+    
+    # Model download service
+    systemd.services.ollama-models = {
+      description = "Download Ollama models";
+      after = [ "ollama.service" ];
+      wantedBy = [ "multi-user.target" ];
+      
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      
+      script = ''
+        ${lib.concatMapStrings (model: ''
+          ${pkgs.curl}/bin/curl -X POST http://localhost:${toString cfg.port}/api/pull \
+            -d '{"name": "${model}"}'
+        '') cfg.models}
+      '';
+    };
+    
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 root root -"
+    ];
+    
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}
+EOF
+```
+
+### 10:30 AM - Database Infrastructure ✅
+
+```bash
+# Step 4: Create database module
+cat > modules/services/databases.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.databases;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.databases = {
+    postgresql = {
+      enable = lib.mkEnableOption "PostgreSQL database";
+      
+      version = lib.mkOption {
+        type = lib.types.str;
+        default = "15";
+        description = "PostgreSQL version";
+      };
+      
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "${paths.state}/postgresql";
+      };
+      
+      databases = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = "Databases to create";
+      };
+      
+      backup = {
+        enable = lib.mkEnableOption "Automatic backups";
+        schedule = lib.mkOption {
+          type = lib.types.str;
+          default = "daily";
+        };
+      };
+    };
+    
+    redis = {
+      enable = lib.mkEnableOption "Redis cache";
+      
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 6379;
+      };
+      
+      maxMemory = lib.mkOption {
+        type = lib.types.str;
+        default = "2gb";
+        description = "Maximum memory";
+      };
+    };
+    
+    influxdb = {
+      enable = lib.mkEnableOption "InfluxDB time-series database";
+      
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8086;
+      };
+    };
+  };
+  
+  config = lib.mkMerge [
+    (lib.mkIf cfg.postgresql.enable {
+      services.postgresql = {
+        enable = true;
+        package = pkgs."postgresql_${cfg.postgresql.version}";
+        dataDir = cfg.postgresql.dataDir;
+        
+        ensureDatabases = cfg.postgresql.databases;
+        
+        authentication = ''
+          local all all trust
+          host all all 127.0.0.1/32 trust
+          host all all ::1/128 trust
+        '';
+      };
+      
+      # Backup service
+      systemd.services.postgresql-backup = lib.mkIf cfg.postgresql.backup.enable {
+        description = "PostgreSQL backup";
+        serviceConfig = {
+          Type = "oneshot";
+          User = "postgres";
+          ExecStart = "${pkgs.postgresql}/bin/pg_dumpall -f ${paths.backup}/postgresql-$(date +%Y%m%d).sql";
+        };
+      };
+      
+      systemd.timers.postgresql-backup = lib.mkIf cfg.postgresql.backup.enable {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.postgresql.backup.schedule;
+          Persistent = true;
+        };
+      };
+    })
+    
+    (lib.mkIf cfg.redis.enable {
+      services.redis.servers.main = {
+        enable = true;
+        port = cfg.redis.port;
+        settings = {
+          maxmemory = cfg.redis.maxMemory;
+          maxmemory-policy = "allkeys-lru";
+        };
+      };
+    })
+    
+    (lib.mkIf cfg.influxdb.enable {
+      services.influxdb2 = {
+        enable = true;
+        settings = {
+          http-bind-address = ":${toString cfg.influxdb.port}";
+        };
+      };
+      
+      networking.firewall.allowedTCPPorts = [ cfg.influxdb.port ];
+    })
+  ];
+}
+EOF
+```
+
+## Afternoon Session (3 hours)
+
+### 2:00 PM - Create Business/AI Profile ✅
+
+```bash
+# Step 5: Create business profile
+cat > profiles/business.nix << 'EOF'
+{ ... }:
+{
+  imports = [
+    ../modules/services/business-api.nix
+    ../modules/services/databases.nix
+  ];
+  
+  hwc.services.businessApi = {
+    enable = true;
+    apis = {
+      invoicing.enable = true;
+      crm.enable = true;
+      analytics.enable = true;
+    };
+  };
+  
+  hwc.services.databases = {
+    postgresql = {
+      enable = true;
+      databases = [ "invoicing" "crm" "analytics" ];
+      backup.enable = true;
+    };
+    redis.enable = true;
+  };
+}
+EOF
+
+# Step 6: Create AI profile
+cat > profiles/ai.nix << 'EOF'
+{ ... }:
+{
+  imports = [
+    ../modules/services/ai-bible.nix
+    ../modules/services/ollama.nix
+  ];
+  
+  hwc.services.aiBible = {
+    enable = true;
+    features = {
+      autoGeneration = true;
+      llmIntegration = true;
+    };
+    llm = {
+      provider = "ollama";
+      model = "llama2";
+    };
+  };
+  
+  hwc.services.ollama = {
+    enable = true;
+    enableGpu = true;
+    models = [ "llama2" "codellama" "mistral" ];
+  };
+}
+EOF
+
+# Step 7: Create migration script for AI Bible files
+cat > operations/migration/migrate-ai-bible.sh << 'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Migrating AI Bible System ==="
+
+OLD_BASE="/etc/nixos"
+NEW_BASE="/etc/nixos-next"
+
+# Copy Python scripts
+echo "Copying Python scripts..."
+mkdir -p "$NEW_BASE/modules/ai-bible/scripts"
+cp "$OLD_BASE/scripts/bible_"*.py "$NEW_BASE/modules/ai-bible/scripts/"
+
+# Copy prompts
+echo "Copying prompts..."
+mkdir -p "$NEW_BASE/modules/ai-bible/prompts"
+cp -r "$OLD_BASE/prompts/bible_prompts/" "$NEW_BASE/modules/ai-bible/prompts/"
+
+# Copy config files
+echo "Copying configuration..."
+cp "$OLD_BASE/config/bible_"*.yaml "$NEW_BASE/modules/ai-bible/data/"
+
+echo "✅ AI Bible system files migrated"
+echo "📝 Remember to update paths in the Python scripts"
+EOF
+chmod +x operations/migration/migrate-ai-bible.sh
+
+# Step 8: Test combined profile
+cat > machines/business-ai-test.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    /etc/nixos/hosts/server/hardware-configuration.nix
+    ../profiles/base.nix
+    ../profiles/business.nix
+    ../profiles/ai.nix
+    ../profiles/monitoring.nix
+  ];
+  
+  networking.hostName = "business-ai-test";
+  
+  # GPU for AI workloads
+  hwc.gpu.nvidia = {
+    enable = true;
+    containerRuntime = true;
+  };
+  
+  users.users.eric = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "docker" ];
+  };
+  
+  boot.loader.systemd-boot.enable = true;
+  system.stateVersion = "24.05";
+}
+EOF
+
+sudo nixos-rebuild build --flake .#business-ai-test
+```
+
+### 4:00 PM - Document Complex Service Patterns ✅
+
+```bash
+# Step 9: Create patterns documentation
+cat > docs/MIGRATION_PATTERNS.md << 'EOF'
+# Migration Patterns
+
+## Pattern 1: Simple Containerized Service
+```nix
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.myservice;
+in {
+  options = { ... };
+  config = lib.mkIf cfg.enable {
+    virtualisation.oci-containers.containers.myservice = { ... };
+  };
+}
+```
+
+## Pattern 2: Service with GPU Support
+
+```nix
+extraOptions = lib.optionals cfg.enableGpu [
+  "--gpus=all"
+  "--runtime=nvidia"
+];
+```
+
+## Pattern 3: Service with State Management
+
+```nix
+systemd.tmpfiles.rules = [
+  "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} -"
+];
+```
+
+## Pattern 4: Service with Dependencies
+
+```nix
+after = [ "network.target" ] ++ 
+  lib.optional cfg.needsDatabase "postgresql.service";
+```
+
+## Pattern 5: Service with Scheduled Tasks
+
+```nix
+systemd.timers.myservice-task = {
+  wantedBy = [ "timers.target" ];
+  timerConfig.OnCalendar = "daily";
+};
+```
+
+EOF
+
+# Step 10: Update migration log
+
+cat >> MIGRATION_LOG.md << 'EOF'
+
+## Day 8: $(date +%Y-%m-%d)
+
+- [x] Business API services
+- [x] AI Bible system
+- [x] Ollama local LLM
+- [x] Database infrastructure
+- [x] Business profile
+- [x] AI profile
+
+Services migrated: 15+ total
+Complex services now included:
+
+- AI Bible with auto-generation
+- Ollama with GPU support
+- PostgreSQL with backups
+- Redis cache
+- Business APIs
+EOF
+
+git add -A
+git commit -m "Day 8: Business services and AI infrastructure"
+```
+
+## End of Day 8 Checklist
+- [ ] Business services migrated
+- [ ] AI Bible system complete
+- [ ] Database layer established
+- [ ] Profiles for business/AI created
+- [ ] 15+ services migrated total

--- a/day9-security-networking.md
+++ b/day9-security-networking.md
@@ -1,0 +1,328 @@
+# Day 9: Security & Advanced Networking (5-6 hours)
+
+## Morning Session (3 hours)
+### 9:00 AM - Security Infrastructure ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 1: Create comprehensive security module
+cat > modules/infrastructure/security.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.security;
+in {
+  options.hwc.security = {
+    enable = lib.mkEnableOption "Security hardening";
+    
+    firewall = {
+      strictMode = lib.mkEnableOption "Strict firewall mode";
+      
+      allowedServices = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "ssh" "http" "https" ];
+        description = "Allowed services";
+      };
+      
+      trustedInterfaces = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "lo" ];
+        description = "Trusted network interfaces";
+      };
+    };
+    
+    fail2ban = {
+      enable = lib.mkEnableOption "Fail2ban intrusion prevention";
+      
+      maxRetries = lib.mkOption {
+        type = lib.types.int;
+        default = 5;
+        description = "Max failed attempts";
+      };
+      
+      banTime = lib.mkOption {
+        type = lib.types.str;
+        default = "10m";
+        description = "Ban duration";
+      };
+    };
+    
+    ssh = {
+      passwordAuthentication = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Allow password auth";
+      };
+      
+      permitRootLogin = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Allow root SSH";
+      };
+      
+      authorizedKeys = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+        default = {};
+        description = "SSH authorized keys per user";
+      };
+    };
+    
+    audit = {
+      enable = lib.mkEnableOption "Security auditing";
+      
+      rules = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = "Audit rules";
+      };
+    };
+  };
+  
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    # Firewall configuration
+    {
+      networking.firewall = {
+        enable = true;
+        allowPing = !cfg.firewall.strictMode;
+        trustedInterfaces = cfg.firewall.trustedInterfaces;
+        
+        # Service-based rules
+        allowedTCPPorts = lib.flatten [
+          (lib.optional (elem "ssh" cfg.firewall.allowedServices) 22)
+          (lib.optional (elem "http" cfg.firewall.allowedServices) 80)
+          (lib.optional (elem "https" cfg.firewall.allowedServices) 443)
+        ];
+        
+        extraCommands = lib.optionalString cfg.firewall.strictMode ''
+          # Drop all forwarding by default
+          iptables -P FORWARD DROP
+          
+          # Rate limiting
+          iptables -A INPUT -p tcp --dport 22 -m state --state NEW -m recent --set
+          iptables -A INPUT -p tcp --dport 22 -m state --state NEW -m recent \
+            --update --seconds 60 --hitcount 4 -j DROP
+        '';
+      };
+    }
+    
+    # SSH hardening
+    {
+      services.openssh = {
+        enable = true;
+        settings = {
+          PasswordAuthentication = cfg.ssh.passwordAuthentication;
+          PermitRootLogin = if cfg.ssh.permitRootLogin then "yes" else "no";
+          KbdInteractiveAuthentication = false;
+          X11Forwarding = false;
+          StrictModes = true;
+        };
+        
+        extraConfig = ''
+          Protocol 2
+          ClientAliveInterval 300
+          ClientAliveCountMax 2
+          MaxAuthTries 3
+          MaxSessions 10
+        '';
+      };
+      
+      # Add authorized keys
+      users.users = lib.mapAttrs (user: keys: {
+        openssh.authorizedKeys.keys = keys;
+      }) cfg.ssh.authorizedKeys;
+    }
+    
+    # Fail2ban
+    (lib.mkIf cfg.fail2ban.enable {
+      services.fail2ban = {
+        enable = true;
+        maxretry = cfg.fail2ban.maxRetries;
+        bantime = cfg.fail2ban.banTime;
+        
+        jails = {
+          ssh = {
+            enabled = true;
+            filter = "sshd";
+            maxretry = 3;
+          };
+          
+          nginx = lib.mkIf config.services.nginx.enable {
+            enabled = true;
+            filter = "nginx-http-auth";
+          };
+        };
+      };
+    })
+    
+    # Audit system
+    (lib.mkIf cfg.audit.enable {
+      security.auditd.enable = true;
+      security.audit.enable = true;
+      security.audit.rules = cfg.audit.rules;
+      
+      # Default audit rules
+      security.audit.rules = lib.mkDefault ''
+        # Log all commands
+        -a exit,always -F arch=b64 -S execve
+        
+        # Log file access
+        -w /etc/passwd -p wa -k passwd_changes
+        -w /etc/shadow -p wa -k shadow_changes
+        
+        # Log network connections
+        -a exit,always -F arch=b64 -S connect -S accept
+      '';
+    })
+    
+    # General hardening
+    {
+      # Kernel hardening
+      boot.kernel.sysctl = {
+        "kernel.unprivileged_bpf_disabled" = 1;
+        "net.core.bpf_jit_harden" = 2;
+        "kernel.ftrace_enabled" = false;
+      };
+      
+      # Security packages
+      environment.systemPackages = with pkgs; [
+        aide      # Intrusion detection
+        lynis     # Security auditing
+        clamav    # Antivirus
+        rkhunter  # Rootkit hunter
+      ];
+    }
+  ]);
+}
+EOF
+
+# Step 2: Create VPN/Tailscale module
+cat > modules/services/vpn.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.vpn;
+in {
+  options.hwc.services.vpn = {
+    tailscale = {
+      enable = lib.mkEnableOption "Tailscale VPN";
+      
+      authKeyFile = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to auth key file";
+      };
+      
+      exitNode = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Act as exit node";
+      };
+      
+      advertiseRoutes = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = "Routes to advertise";
+      };
+    };
+    
+    wireguard = {
+      enable = lib.mkEnableOption "WireGuard VPN";
+      
+      interfaces = lib.mkOption {
+        type = lib.types.attrsOf lib.types.attrs;
+        default = {};
+        description = "WireGuard interfaces";
+      };
+    };
+  };
+  
+  config = lib.mkMerge [
+    (lib.mkIf cfg.tailscale.enable {
+      services.tailscale = {
+        enable = true;
+        authKeyFile = cfg.tailscale.authKeyFile;
+        useRoutingFeatures = if cfg.tailscale.exitNode then "both" else "client";
+        extraUpFlags = cfg.tailscale.advertiseRoutes;
+      };
+      
+      networking.firewall = {
+        checkReversePath = "loose";
+        trustedInterfaces = [ "tailscale0" ];
+      };
+      
+      # Enable IP forwarding if exit node
+      boot.kernel.sysctl = lib.mkIf cfg.tailscale.exitNode {
+        "net.ipv4.ip_forward" = 1;
+        "net.ipv6.conf.all.forwarding" = 1;
+      };
+    })
+    
+    (lib.mkIf cfg.wireguard.enable {
+      networking.wg-quick.interfaces = cfg.wireguard.interfaces;
+      
+      networking.firewall.allowedUDPPorts = [ 51820 ];
+    })
+  ];
+}
+EOF
+
+# Step 3: Create advanced networking module
+cat > modules/infrastructure/networking.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.networking;
+in {
+  options.hwc.networking = {
+    vlans = lib.mkOption {
+      type = lib.types.attrsOf lib.types.attrs;
+      default = {};
+      description = "VLAN configurations";
+      example = {
+        management = { id = 10; interface = "eth0"; };
+        storage = { id = 20; interface = "eth0"; };
+      };
+    };
+    
+    bridges = lib.mkOption {
+      type = lib.types.attrsOf lib.types.attrs;
+      default = {};
+      description = "Bridge configurations";
+    };
+    
+    staticRoutes = lib.mkOption {
+      type = lib.types.listOf lib.types.attrs;
+      default = [];
+      description = "Static routes";
+    };
+    
+    dnsServers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "1.1.1.1" "8.8.8.8" ];
+      description = "DNS servers";
+    };
+    
+    search = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "local" ];
+      description = "DNS search domains";
+    };
+    
+    mtu = lib.mkOption {
+      type = lib.types.int;
+      default = 1500;
+      description = "Default MTU";
+    };
+  };
+  
+  config = {
+    # VLAN configuration
+    networking.vlans = lib.mapAttrs (name: vlan: {
+      id = vlan.id;
+      interface = vlan.interface;
+    }) cfg.vlans;
+    
+    # Bridge configuration
+    networking.bridges = cfg.bridges;
+    
+    # Static routes
+    networking.interfaces.eth0.ipv
+EOF
+```

--- a/docs/MIGRATION_PATTERNS.md
+++ b/docs/MIGRATION_PATTERNS.md
@@ -1,0 +1,48 @@
+# Migration Patterns
+
+## Pattern 1: Simple Containerized Service
+```nix
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.myservice;
+in {
+  options = { ... };
+  config = lib.mkIf cfg.enable {
+    virtualisation.oci-containers.containers.myservice = { ... };
+  };
+}
+```
+
+## Pattern 2: Service with GPU Support
+
+```nix
+extraOptions = lib.optionals cfg.enableGpu [
+  "--gpus=all"
+  "--runtime=nvidia"
+];
+```
+
+## Pattern 3: Service with State Management
+
+```nix
+systemd.tmpfiles.rules = [
+  "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} -"
+];
+```
+
+## Pattern 4: Service with Dependencies
+
+```nix
+after = [ "network.target" ] ++ 
+  lib.optional cfg.needsDatabase "postgresql.service";
+```
+
+## Pattern 5: Service with Scheduled Tasks
+
+```nix
+systemd.timers.myservice-task = {
+  wantedBy = [ "timers.target" ];
+  timerConfig.OnCalendar = "daily";
+};
+```
+

--- a/machines/business-ai-test.nix
+++ b/machines/business-ai-test.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    /etc/nixos/hosts/server/hardware-configuration.nix
+    ../profiles/base.nix
+    ../profiles/business.nix
+    ../profiles/ai.nix
+    ../profiles/monitoring.nix
+  ];
+  
+  networking.hostName = "business-ai-test";
+  
+  # GPU for AI workloads
+  hwc.gpu.nvidia = {
+    enable = true;
+    containerRuntime = true;
+  };
+  
+  users.users.eric = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "docker" ];
+  };
+  
+  boot.loader.systemd-boot.enable = true;
+  system.stateVersion = "24.05";
+}

--- a/modules/services/ai-bible.nix
+++ b/modules/services/ai-bible.nix
@@ -1,0 +1,156 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.aiBible;
+  paths = config.hwc.paths;
+  
+  # Python environment for AI services
+  pythonEnv = pkgs.python3.withPackages (ps: with ps; [
+    fastapi uvicorn pydantic
+    torch transformers
+    pandas numpy
+    pyyaml
+  ]);
+in {
+  options.hwc.services.aiBible = {
+    enable = lib.mkEnableOption "AI Bible documentation system";
+    
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8888;
+      description = "API port";
+    };
+    
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.state}/ai-bible";
+    };
+    
+    features = {
+      autoGeneration = lib.mkEnableOption "Auto documentation generation";
+      
+      llmIntegration = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable LLM integration";
+      };
+      
+      categories = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "system_architecture"
+          "container_services"
+          "hardware_gpu"
+          "monitoring_observability"
+          "storage_data"
+        ];
+        description = "Documentation categories";
+      };
+    };
+    
+    llm = {
+      provider = lib.mkOption {
+        type = lib.types.enum [ "ollama" "openai" "anthropic" ];
+        default = "ollama";
+      };
+      
+      model = lib.mkOption {
+        type = lib.types.str;
+        default = "llama2";
+        description = "LLM model to use";
+      };
+      
+      endpoint = lib.mkOption {
+        type = lib.types.str;
+        default = "http://localhost:11434";
+        description = "LLM API endpoint";
+      };
+    };
+  };
+  
+  config = lib.mkIf cfg.enable {
+    # Main AI Bible service
+    systemd.services.ai-bible = {
+      description = "AI Bible Documentation System";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ] ++ 
+        lib.optional (cfg.llm.provider == "ollama") "ollama.service";
+      
+      environment = {
+        BIBLE_PORT = toString cfg.port;
+        BIBLE_DATA = cfg.dataDir;
+        LLM_PROVIDER = cfg.llm.provider;
+        LLM_MODEL = cfg.llm.model;
+        LLM_ENDPOINT = cfg.llm.endpoint;
+      };
+      
+      serviceConfig = {
+        ExecStart = "${pythonEnv}/bin/python ${cfg.dataDir}/bible_system.py";
+        WorkingDirectory = cfg.dataDir;
+        Restart = "on-failure";
+        User = "ai-bible";
+        Group = "ai-bible";
+        
+        # Security
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir ];
+      };
+    };
+    
+    # Auto-generation timer
+    systemd.timers.ai-bible-generate = lib.mkIf cfg.features.autoGeneration {
+      description = "AI Bible auto-generation timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
+    };
+    
+    systemd.services.ai-bible-generate = lib.mkIf cfg.features.autoGeneration {
+      description = "Generate AI Bible documentation";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pythonEnv}/bin/python ${cfg.dataDir}/bible_rewriter.py";
+        User = "ai-bible";
+      };
+    };
+    
+    # Provision Bible system files
+    environment.etc = {
+      "ai-bible/config.yaml".text = lib.generators.toYAML {} {
+        categories = cfg.features.categories;
+        llm = {
+          provider = cfg.llm.provider;
+          model = cfg.llm.model;
+          endpoint = cfg.llm.endpoint;
+        };
+        features = {
+          auto_generation = cfg.features.autoGeneration;
+          llm_integration = cfg.features.llmIntegration;
+        };
+      };
+      
+      "ai-bible/prompts".source = ./modules/ai-bible/prompts;
+    };
+    
+    # User and permissions
+    users.users.ai-bible = {
+      isSystemUser = true;
+      group = "ai-bible";
+      home = cfg.dataDir;
+    };
+    users.groups.ai-bible = {};
+    
+    # Setup directories and copy Python scripts
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0750 ai-bible ai-bible -"
+      "d ${cfg.dataDir}/bibles 0750 ai-bible ai-bible -"
+      "d ${cfg.dataDir}/prompts 0750 ai-bible ai-bible -"
+      "d ${cfg.dataDir}/output 0750 ai-bible ai-bible -"
+    ];
+    
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/modules/services/business-api.nix
+++ b/modules/services/business-api.nix
@@ -1,0 +1,83 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.businessApi;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.businessApi = {
+    enable = lib.mkEnableOption "Business API services";
+
+    apis = {
+      invoicing = {
+        enable = lib.mkEnableOption "Invoicing API";
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3001;
+        };
+        database = lib.mkOption {
+          type = lib.types.str;
+          default = "postgresql://localhost/invoicing";
+        };
+      };
+
+      crm = {
+        enable = lib.mkEnableOption "CRM API";
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3002;
+        };
+      };
+
+      analytics = {
+        enable = lib.mkEnableOption "Analytics API";
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 3003;
+        };
+      };
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.state}/business";
+    };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    (lib.mkIf cfg.apis.invoicing.enable {
+      virtualisation.oci-containers.containers.invoicing-api = {
+        image = "business/invoicing:latest";
+        ports = [ "${toString cfg.apis.invoicing.port}:3000" ];
+        volumes = [
+          "${cfg.dataDir}/invoicing:/data"
+        ];
+        environment = {
+          DATABASE_URL = cfg.apis.invoicing.database;
+          NODE_ENV = "production";
+        };
+      };
+    })
+
+    (lib.mkIf cfg.apis.crm.enable {
+      virtualisation.oci-containers.containers.crm-api = {
+        image = "business/crm:latest";
+        ports = [ "${toString cfg.apis.crm.port}:3000" ];
+        volumes = [
+          "${cfg.dataDir}/crm:/data"
+        ];
+      };
+    })
+
+    {
+      systemd.tmpfiles.rules = [
+        "d ${cfg.dataDir} 0750 root root -"
+        "d ${cfg.dataDir}/invoicing 0750 root root -"
+        "d ${cfg.dataDir}/crm 0750 root root -"
+      ];
+
+      networking.firewall.allowedTCPPorts = lib.flatten [
+        (lib.optional cfg.apis.invoicing.enable cfg.apis.invoicing.port)
+        (lib.optional cfg.apis.crm.enable cfg.apis.crm.port)
+      ];
+    }
+  ]);
+}

--- a/modules/services/databases.nix
+++ b/modules/services/databases.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.databases;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.databases = {
+    postgresql = {
+      enable = lib.mkEnableOption "PostgreSQL database";
+      
+      version = lib.mkOption {
+        type = lib.types.str;
+        default = "15";
+        description = "PostgreSQL version";
+      };
+      
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "${paths.state}/postgresql";
+      };
+      
+      databases = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = "Databases to create";
+      };
+      
+      backup = {
+        enable = lib.mkEnableOption "Automatic backups";
+        schedule = lib.mkOption {
+          type = lib.types.str;
+          default = "daily";
+        };
+      };
+    };
+    
+    redis = {
+      enable = lib.mkEnableOption "Redis cache";
+      
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 6379;
+      };
+      
+      maxMemory = lib.mkOption {
+        type = lib.types.str;
+        default = "2gb";
+        description = "Maximum memory";
+      };
+    };
+    
+    influxdb = {
+      enable = lib.mkEnableOption "InfluxDB time-series database";
+      
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8086;
+      };
+    };
+  };
+  
+  config = lib.mkMerge [
+    (lib.mkIf cfg.postgresql.enable {
+      services.postgresql = {
+        enable = true;
+        package = pkgs."postgresql_${cfg.postgresql.version}";
+        dataDir = cfg.postgresql.dataDir;
+        
+        ensureDatabases = cfg.postgresql.databases;
+        
+        authentication = ''
+          local all all trust
+          host all all 127.0.0.1/32 trust
+          host all all ::1/128 trust
+        '';
+      };
+      
+      # Backup service
+      systemd.services.postgresql-backup = lib.mkIf cfg.postgresql.backup.enable {
+        description = "PostgreSQL backup";
+        serviceConfig = {
+          Type = "oneshot";
+          User = "postgres";
+          ExecStart = "${pkgs.postgresql}/bin/pg_dumpall -f ${paths.backup}/postgresql-$(date +%Y%m%d).sql";
+        };
+      };
+      
+      systemd.timers.postgresql-backup = lib.mkIf cfg.postgresql.backup.enable {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.postgresql.backup.schedule;
+          Persistent = true;
+        };
+      };
+    })
+    
+    (lib.mkIf cfg.redis.enable {
+      services.redis.servers.main = {
+        enable = true;
+        port = cfg.redis.port;
+        settings = {
+          maxmemory = cfg.redis.maxMemory;
+          maxmemory-policy = "allkeys-lru";
+        };
+      };
+    })
+    
+    (lib.mkIf cfg.influxdb.enable {
+      services.influxdb2 = {
+        enable = true;
+        settings = {
+          http-bind-address = ":${toString cfg.influxdb.port}";
+        };
+      };
+      
+      networking.firewall.allowedTCPPorts = [ cfg.influxdb.port ];
+    })
+  ];
+}

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -1,0 +1,84 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.ollama;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.ollama = {
+    enable = lib.mkEnableOption "Ollama local LLM";
+    
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 11434;
+      description = "API port";
+    };
+    
+    models = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "llama2" "codellama" ];
+      description = "Models to download";
+    };
+    
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.hot}/ollama";
+      description = "Model storage directory";
+    };
+    
+    enableGpu = lib.mkEnableOption "GPU acceleration";
+    
+    memoryLimit = lib.mkOption {
+      type = lib.types.str;
+      default = "16G";
+      description = "Memory limit";
+    };
+  };
+  
+  config = lib.mkIf cfg.enable {
+    virtualisation.oci-containers.containers.ollama = {
+      image = "ollama/ollama:latest";
+      
+      ports = [ "${toString cfg.port}:11434" ];
+      
+      volumes = [
+        "${cfg.dataDir}:/root/.ollama"
+      ];
+      
+      environment = {
+        OLLAMA_HOST = "0.0.0.0";
+        OLLAMA_MODELS = cfg.dataDir;
+      };
+      
+      extraOptions = lib.optionals cfg.enableGpu [
+        "--gpus=all"
+        "--device=/dev/nvidia0"
+        "--device=/dev/nvidiactl"
+        "--device=/dev/nvidia-uvm"
+      ];
+    };
+    
+    # Model download service
+    systemd.services.ollama-models = {
+      description = "Download Ollama models";
+      after = [ "ollama.service" ];
+      wantedBy = [ "multi-user.target" ];
+      
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      
+      script = ''
+        ${lib.concatMapStrings (model: ''
+          ${pkgs.curl}/bin/curl -X POST http://localhost:${toString cfg.port}/api/pull \
+            -d '{"name": "${model}"}'
+        '') cfg.models}
+      '';
+    };
+    
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 root root -"
+    ];
+    
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/operations/migration/migrate-ai-bible.sh
+++ b/operations/migration/migrate-ai-bible.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Migrating AI Bible System ==="
+
+OLD_BASE="/etc/nixos"
+NEW_BASE="/etc/nixos-next"
+
+# Copy Python scripts
+echo "Copying Python scripts..."
+mkdir -p "$NEW_BASE/modules/ai-bible/scripts"
+cp "$OLD_BASE/scripts/bible_"*.py "$NEW_BASE/modules/ai-bible/scripts/"
+
+# Copy prompts
+echo "Copying prompts..."
+mkdir -p "$NEW_BASE/modules/ai-bible/prompts"
+cp -r "$OLD_BASE/prompts/bible_prompts/" "$NEW_BASE/modules/ai-bible/prompts/"
+
+# Copy config files
+echo "Copying configuration..."
+cp "$OLD_BASE/config/bible_"*.yaml "$NEW_BASE/modules/ai-bible/data/"
+
+echo "✅ AI Bible system files migrated"
+echo "📝 Remember to update paths in the Python scripts"

--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -1,0 +1,25 @@
+{ ... }:
+{
+  imports = [
+    ../modules/services/ai-bible.nix
+    ../modules/services/ollama.nix
+  ];
+  
+  hwc.services.aiBible = {
+    enable = true;
+    features = {
+      autoGeneration = true;
+      llmIntegration = true;
+    };
+    llm = {
+      provider = "ollama";
+      model = "llama2";
+    };
+  };
+  
+  hwc.services.ollama = {
+    enable = true;
+    enableGpu = true;
+    models = [ "llama2" "codellama" "mistral" ];
+  };
+}

--- a/profiles/business.nix
+++ b/profiles/business.nix
@@ -1,0 +1,25 @@
+{ ... }:
+{
+  imports = [
+    ../modules/services/business-api.nix
+    ../modules/services/databases.nix
+  ];
+  
+  hwc.services.businessApi = {
+    enable = true;
+    apis = {
+      invoicing.enable = true;
+      crm.enable = true;
+      analytics.enable = true;
+    };
+  };
+  
+  hwc.services.databases = {
+    postgresql = {
+      enable = true;
+      databases = [ "invoicing" "crm" "analytics" ];
+      backup.enable = true;
+    };
+    redis.enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
- add business API, AI Bible, Ollama, and database service modules
- define business and AI profiles and migration script
- document migration patterns and provide planning docs for days 8 and 9

## Testing
- `bash -n operations/migration/migrate-ai-bible.sh`
- `nix-instantiate --parse modules/services/business-api.nix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e5370987c8330baf07d23d03c1cfb