### PR TITLE
Add NixOS refactor plan documentation

### DIFF
--- a/etc/nixos/refactor-plan/QUICK_REFERENCE.md
+++ b/etc/nixos/refactor-plan/QUICK_REFERENCE.md
@@ -1,0 +1,55 @@
+# Quick Reference Card
+
+## Daily Commands
+```bash
+# Check old system
+cd /etc/nixos && sudo nixos-rebuild build --flake .#hwc-server
+
+# Check new system  
+cd /etc/nixos-next && sudo nixos-rebuild build --flake .#test-refactor
+
+# Quick validation
+/etc/nixos-next/operations/validation/quick-check.sh
+```
+
+## Emergency Rollback
+
+```bash
+# If something breaks:
+cd /etc/nixos
+git checkout main
+sudo nixos-rebuild switch --flake .#hwc-server
+
+# Nuclear option:
+sudo nixos-rebuild switch --rollback
+```
+
+## Progress Tracker
+
+|Day|Goal            |Status|Rollback Point        |
+|---|----------------|------|----------------------|
+|1  |Create structure|[ ]   |Git branch            |
+|2  |First build     |[ ]   |Delete /etc/nixos-next|
+|3  |First service   |[ ]   |Remove service module |
+
+## Key Paths
+
+- Old (working): `/etc/nixos`
+- New (building): `/etc/nixos-next`
+- Logs: `/etc/nixos-next/MIGRATION_LOG.md`
+
+## Mental Model
+
+- Old house: Still living in it (don’t touch!)
+- New house: Building next door (safe to experiment)
+- Moving day: Not for weeks (no pressure)
+
+## How to Use These Files
+
+1. **Save all files** to `/etc/nixos/refactor-plan/`
+2. **Print the day's plan** each morning
+3. **Check off items** as you complete them
+4. **Stop when tired** - there's no deadline
+5. **If stuck**, just stop for the day
+
+Each day builds on the previous, but if you miss a day or need to repeat one, that's fine! The old system keeps working regardless.

--- a/etc/nixos/refactor-plan/day1-foundation.md
+++ b/etc/nixos/refactor-plan/day1-foundation.md
@@ -1,0 +1,137 @@
+# Day 1: Foundation & Safety (2-3 hours total)
+
+## Morning Session (1 hour)
+### 9:00 AM - Safety Setup ✅
+
+```bash
+cd /etc/nixos
+
+# Step 1: Commit current state
+git status
+git add -A
+git commit -m "Pre-refactor snapshot: $(date +%Y-%m-%d)"
+
+# Step 2: Create safety branches
+git branch refactor-backup-$(date +%Y%m%d)
+git checkout -b refactor-attempt-1
+
+# Step 3: Document current generation
+sudo nix-env --list-generations --profile /nix/var/nix/profiles/system | tail -3 > generation-backup.txt
+
+# Step 4: Test current builds
+time sudo nixos-rebuild build --flake .#hwc-server
+time sudo nixos-rebuild build --flake .#hwc-laptop
+```
+
+**CHECKPOINT**: Both builds should succeed. If not, STOP and fix.
+
+### 10:00 AM - Create Parallel Structure ✅
+
+```bash
+# Step 5: Create new repository
+sudo mkdir -p /etc/nixos-next
+sudo chown -R $(whoami):users /etc/nixos-next
+cd /etc/nixos-next
+git init
+
+# Step 6: Create directory structure
+mkdir -p {modules,machines,lib,operations,tests}
+mkdir -p modules/{system,services,infrastructure}
+mkdir -p operations/{scripts,validation}
+
+# Step 7: Create initial flake
+cat > flake.nix << 'EOF'
+{
+  description = "Refactored NixOS Configuration";
+  
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
+  };
+  
+  outputs = { self, nixpkgs, nixpkgs-stable }: {
+    nixosConfigurations = {
+      # Machines will be added here
+    };
+  };
+}
+EOF
+
+git add -A
+git commit -m "Initial structure"
+```
+
+## Afternoon Session (1-2 hours)
+
+### 2:00 PM - Create Tracking System ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 8: Create migration tracking
+cat > MIGRATION_LOG.md << 'EOF'
+# Migration Log
+
+## Day 1: $(date +%Y-%m-%d)
+- [ ] Created backup: generation ___
+- [ ] Created parallel structure at /etc/nixos-next
+- [ ] Created base directories
+- [ ] Initial flake created
+- [ ] Test module created
+
+## Status
+- Old repo: /etc/nixos (untouched)
+- New repo: /etc/nixos-next (empty)
+- Can rollback: YES
+EOF
+
+# Step 9: Create validation script
+cat > operations/validation/quick-check.sh << 'EOF'
+#!/usr/bin/env bash
+echo "=== Quick Validation ==="
+echo "Old repo builds: $(cd /etc/nixos && nixos-rebuild build --flake .#hwc-server &>/dev/null && echo "✅" || echo "❌")"
+echo "New repo exists: $([ -d /etc/nixos-next ] && echo "✅" || echo "❌")"
+echo "Git status clean: $(cd /etc/nixos-next && git status --porcelain | wc -l | grep -q "^0$" && echo "✅" || echo "❌")"
+EOF
+chmod +x operations/validation/quick-check.sh
+```
+
+### 3:00 PM - First Test Module ✅
+
+```bash
+# Step 10: Create simplest possible module
+cat > modules/system/test.nix << 'EOF'
+{ config, lib, ... }:
+{
+  options.hwc.test = {
+    enable = lib.mkEnableOption "Test module";
+  };
+  
+  config = lib.mkIf config.hwc.test.enable {
+    environment.etc."nixos-refactor-test.txt".text = "Working!";
+  };
+}
+EOF
+
+git add -A
+git commit -m "Day 1 complete: Foundation established"
+```
+
+## End of Day 1 Checklist
+
+- [ ] Old system still builds
+- [ ] New structure created at /etc/nixos-next
+- [ ] Git initialized in new structure
+- [ ] Migration log started
+- [ ] Test module created
+
+## If Something Goes Wrong
+
+```bash
+# Just delete the new structure and start over tomorrow
+sudo rm -rf /etc/nixos-next
+cd /etc/nixos
+git checkout main
+```
+
+**Day 1 Success Criteria**: New structure exists, old system untouched

--- a/etc/nixos/refactor-plan/day2-first-config.md
+++ b/etc/nixos/refactor-plan/day2-first-config.md
@@ -1,0 +1,198 @@
+# Day 2: First Working Configuration (2-3 hours)
+
+## Morning Session (1.5 hours)
+### 9:00 AM - Review & Validate Day 1 ✅
+
+```bash
+# Step 1: Validate yesterday's work
+cd /etc/nixos
+git status  # Should be clean
+sudo nixos-rebuild build --flake .#hwc-server  # Should still work
+
+cd /etc/nixos-next
+./operations/validation/quick-check.sh
+
+# Step 2: Update migration log
+echo "## Day 2: $(date +%Y-%m-%d)" >> MIGRATION_LOG.md
+```
+
+### 9:30 AM - Create Core Paths Module ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 3: Create paths module (critical for everything else)
+cat > modules/system/paths.nix << 'EOF'
+{ lib, config, ... }:
+{
+  options.hwc.paths = {
+    root = lib.mkOption {
+      type = lib.types.path;
+      default = "/";
+      description = "System root";
+    };
+    
+    hot = lib.mkOption {
+      type = lib.types.path;
+      default = "/mnt/hot";
+      description = "Hot storage";
+    };
+    
+    media = lib.mkOption {
+      type = lib.types.path;
+      default = "/mnt/media";
+      description = "Media storage";
+    };
+    
+    state = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/hwc";
+      description = "Service state";
+    };
+  };
+  
+  config = {
+    # Ensure directories exist
+    systemd.tmpfiles.rules = [
+      "d ${config.hwc.paths.state} 0755 root root -"
+    ];
+  };
+}
+EOF
+```
+
+### 10:00 AM - Create Minimal Machine Config ✅
+
+```bash
+# Step 4: Create test machine that can actually build
+cat > machines/test-refactor.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    # Import hardware from existing config
+    /etc/nixos/hosts/server/hardware-configuration.nix
+    
+    # Import our modules
+    ../modules/system/paths.nix
+    ../modules/system/test.nix
+  ];
+  
+  # Enable test module
+  hwc.test.enable = true;
+  
+  # Minimal required config
+  networking.hostName = "test-refactor";
+  networking.useDHCP = lib.mkDefault true;
+  
+  # Boot loader (copy from your current)
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+  
+  # Add your user
+  users.users.eric = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "networkmanager" ];
+  };
+  
+  # Basic services
+  services.openssh.enable = true;
+  
+  system.stateVersion = "24.05";
+}
+EOF
+
+# Step 5: Update flake to recognize the machine
+cat > flake.nix << 'EOF'
+{
+  description = "Refactored NixOS Configuration";
+  
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+  
+  outputs = { self, nixpkgs }: {
+    nixosConfigurations = {
+      test-refactor = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [ ./machines/test-refactor.nix ];
+      };
+    };
+  };
+}
+EOF
+```
+
+## Afternoon Session (1.5 hours)
+
+### 2:00 PM - Test First Build ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 6: Attempt first build (WILL LIKELY FAIL - THAT'S OK!)
+sudo nixos-rebuild build --flake .#test-refactor 2>&1 | tee build-attempt-1.log
+
+# Step 7: Fix common issues
+# If missing options, add:
+echo "{ config, lib, pkgs, ... }: {}" > modules/system/compat.nix
+# Then add to imports in machines/test-refactor.nix
+
+# Step 8: Keep trying until it builds
+sudo nixos-rebuild build --flake .#test-refactor
+
+# SUCCESS MESSAGE SHOULD APPEAR
+```
+
+### 3:00 PM - Create Migration Bridge ✅
+
+```bash
+# Step 9: Create bridge to reference old config
+cat > lib/migration-helper.nix << 'EOF'
+{ lib }:
+{
+  # Helper to import from old config
+  importLegacy = path: 
+    import (/etc/nixos + "/${path}");
+  
+  # Helper to track migration status  
+  migrationStatus = service: status:
+    lib.trace "Migration: ${service} is ${status}" true;
+}
+EOF
+
+# Step 10: Document success
+cat >> MIGRATION_LOG.md << 'EOF'
+- [ ] Created paths module
+- [ ] Created test machine config
+- [ ] First successful build
+- [ ] Migration bridge created
+
+Build Output: $(readlink result)
+EOF
+
+git add -A
+git commit -m "Day 2: First successful build"
+```
+
+## End of Day 2 Checklist
+
+- [ ] New config builds successfully
+- [ ] Paths module created
+- [ ] Test machine defined
+- [ ] Old system still untouched
+- [ ] Can build: `sudo nixos-rebuild build --flake /etc/nixos-next#test-refactor`
+
+## Troubleshooting Commands
+
+```bash
+# See what's failing
+sudo nixos-rebuild build --flake .#test-refactor --show-trace
+
+# Check syntax
+nix flake check
+
+# See what would be built
+nix eval .#nixosConfigurations.test-refactor.config.system.build.toplevel
+```
+
+**Day 2 Success**: New structure can build a minimal system

--- a/etc/nixos/refactor-plan/day3-first-service.md
+++ b/etc/nixos/refactor-plan/day3-first-service.md
@@ -1,0 +1,244 @@
+# Day 3: First Service Migration (3-4 hours)
+
+## Morning Session (2 hours)
+### 9:00 AM - Validate Previous Work ✅
+
+```bash
+# Step 1: Ensure both repos still build
+cd /etc/nixos
+sudo nixos-rebuild build --flake .#hwc-server
+
+cd /etc/nixos-next
+sudo nixos-rebuild build --flake .#test-refactor
+
+# Both should succeed before continuing
+```
+
+### 9:30 AM - Choose Simplest Service ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 2: Let's migrate ntfy (simple, stateless service)
+# First, understand the current config
+cat /etc/nixos/hosts/server/modules/ntfy-server.yml
+grep -r "ntfy" /etc/nixos/
+
+# Step 3: Create new module
+cat > modules/services/ntfy.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.hwc.services.ntfy;
+  paths = config.hwc.paths;
+in {
+  options.hwc.services.ntfy = {
+    enable = lib.mkEnableOption "ntfy notification service";
+    
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8093;
+      description = "Port for ntfy";
+    };
+    
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${paths.state}/ntfy";
+      description = "Data directory";
+    };
+  };
+  
+  config = lib.mkIf cfg.enable {
+    # Container configuration
+    virtualisation.oci-containers.containers.ntfy = {
+      image = "binwiederhier/ntfy:latest";
+      ports = [ "${toString cfg.port}:80" ];
+      volumes = [
+        "${cfg.dataDir}:/var/cache/ntfy"
+        "${cfg.dataDir}/etc:/etc/ntfy"
+      ];
+      environment = {
+        TZ = "America/Denver";
+      };
+    };
+    
+    # Ensure directories exist
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0750 root root -"
+      "d ${cfg.dataDir}/etc 0750 root root -"
+    ];
+    
+    # Open firewall
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}
+EOF
+```
+
+### 10:30 AM - Create Service Test ✅
+
+```bash
+# Step 4: Create test for the service
+cat > tests/ntfy-test.nix << 'EOF'
+{ nixpkgs }:
+let
+  nixosTest = nixpkgs.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [
+      ../modules/system/paths.nix
+      ../modules/services/ntfy.nix
+      {
+        hwc.services.ntfy.enable = true;
+        
+        # Minimal config for testing
+        boot.loader.grub.device = "nodev";
+        fileSystems."/" = {
+          device = "none";
+          fsType = "tmpfs";
+        };
+      }
+    ];
+  };
+in
+  nixosTest.config.system.build.toplevel
+EOF
+
+# Step 5: Test the module builds
+nix-build tests/ntfy-test.nix --arg nixpkgs 'import <nixpkgs> {}'
+```
+
+## Afternoon Session (2 hours)
+
+### 2:00 PM - Add Service to Machine ✅
+
+```bash
+cd /etc/nixos-next
+
+# Step 6: Add service to test machine
+cat > machines/test-refactor.nix << 'EOF'
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    /etc/nixos/hosts/server/hardware-configuration.nix
+    ../modules/system/paths.nix
+    ../modules/system/test.nix
+    ../modules/services/ntfy.nix  # NEW!
+  ];
+  
+  # Enable services
+  hwc.test.enable = true;
+  hwc.services.ntfy = {        # NEW!
+    enable = true;
+    port = 8093;
+  };
+  
+  # Core config (unchanged from yesterday)
+  networking.hostName = "test-refactor";
+  networking.useDHCP = lib.mkDefault true;
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+  
+  users.users.eric = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "networkmanager" "docker" ];
+  };
+  
+  # Container runtime (needed for ntfy)
+  virtualisation.docker.enable = true;
+  virtualisation.oci-containers.backend = "docker";
+  
+  services.openssh.enable = true;
+  system.stateVersion = "24.05";
+}
+EOF
+
+# Step 7: Build with service
+sudo nixos-rebuild build --flake .#test-refactor
+```
+
+### 3:00 PM - Create Comparison Test ✅
+
+```bash
+# Step 8: Create validation script
+cat > operations/validation/compare-services.sh << 'EOF'
+#!/usr/bin/env bash
+
+SERVICE="ntfy"
+
+echo "=== Service Comparison: $SERVICE ==="
+
+# Check old config
+echo "Old config location: /etc/nixos/hosts/server/modules/"
+ls -la /etc/nixos/hosts/server/modules/*ntfy* 2>/dev/null || echo "No ntfy in old"
+
+# Check new config  
+echo "New config location: /etc/nixos-next/modules/services/"
+ls -la /etc/nixos-next/modules/services/ntfy.nix
+
+# Compare outputs
+echo ""
+echo "Old build size:"
+du -sh /etc/nixos/result 2>/dev/null || echo "No result link"
+
+echo "New build size:"
+du -sh /etc/nixos-next/result 2>/dev/null || echo "No result link"
+
+echo ""
+echo "✅ Service migrated (not activated, just configured)"
+EOF
+chmod +x operations/validation/compare-services.sh
+
+# Step 9: Document the migration
+cat > operations/MIGRATION_GUIDE.md << 'EOF'
+# Service Migration Guide
+
+## Migrated Services
+1. ntfy - Day 3 - Simple container service
+
+## Migration Process
+1. Copy service from old location
+2. Rewrite using hwc.services.* namespace
+3. Use config.hwc.paths for all paths
+4. Test module builds in isolation
+5. Add to test machine
+6. Validate build
+
+## Next Services (by complexity)
+- [ ] transcript-api (simple, no state)
+- [ ] grafana (medium, has dashboards)
+- [ ] jellyfin (complex, GPU + storage)
+EOF
+
+# Step 10: Commit progress
+git add -A
+git commit -m "Day 3: First service (ntfy) migrated"
+```
+
+## End of Day 3 Checklist
+
+- [ ] First service module created
+- [ ] Service builds in new structure
+- [ ] Test machine includes service
+- [ ] Documentation updated
+- [ ] Old system still untouched
+
+## Validation
+
+```bash
+# Final validation
+cd /etc/nixos-next
+./operations/validation/quick-check.sh
+./operations/validation/compare-services.sh
+
+# Check what was built
+nix-store -q --tree ./result | head -20
+```
+
+## Weekend Homework (Optional)
+
+If you want to continue:
+
+1. Try migrating transcript-api (similar pattern)
+2. Create a profile that groups services
+3. Think about which services to migrate next week
+
+**Day 3 Success**: One real service lives in the new structure!


### PR DESCRIPTION
## Summary
- add Day 1 foundation plan documenting repo setup and safety steps
- add Day 2 plan describing first working configuration and migration helper
- add Day 3 plan for migrating first service and comparison utilities
- add quick reference card with daily commands and rollback instructions

## Testing
- `nix flake check` *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_b_689e53b63f108330880e32a7bc7bd6c9