### PR TITLE
Enable Paperless-NGX document management and Redis support

### DIFF
--- a/machines/server/config.nix
+++ b/machines/server/config.nix
@@ -854,6 +854,9 @@
     enable = lib.mkDefault true;
   };
 
+  # Paperless-NGX document management
+  hwc.business.paperless.enable = lib.mkDefault true;
+
   #============================================================================
   # WEB APPS DOMAIN
   #============================================================================
@@ -940,6 +943,9 @@
       # schedule = "*-*-* 02:30:00";  # default (2:30 AM)
     };
   };
+
+  # Redis (used by Paperless-NGX for async task queue)
+  hwc.data.databases.redis.enable = lib.mkDefault true;
 
   # CloudBeaver - web-based database manager (access via port 12443)
   hwc.data.cloudbeaver.enable = lib.mkDefault true;


### PR DESCRIPTION
## Summary
This change enables Paperless-NGX document management system and its Redis dependency for the server configuration.

## Key Changes
- Enable Paperless-NGX (`hwc.business.paperless`) as a document management solution
- Enable Redis (`hwc.data.databases.redis`) to support Paperless-NGX's asynchronous task queue

## Implementation Details
Both services are enabled with `lib.mkDefault true`, allowing them to be overridden at higher priority levels in the NixOS configuration hierarchy. Redis is explicitly documented as a dependency for Paperless-NGX's async task processing capabilities.

https://claude.ai/code/session_01HGHePJPgg7b7h5sH8o7Zk6