### PR TITLE
feat: wire Alertmanager to ntfy + fix 3 stale false-positive alerts

### DIFF
--- a/domains/alerts/README.md
+++ b/domains/alerts/README.md
@@ -17,6 +17,7 @@ domains/alerts/
 ├── options.nix         # hwc.alerts.* options
 └── parts/
     ├── cli.nix         # hwc-alert CLI tool
+    ├── ntfy-bridge.nix # Alertmanager → ntfy bridge service
     ├── server.nix      # ntfy notification server container
     └── slack-webhook.nix # Webhook scripts with retry logic
 ```
@@ -110,6 +111,7 @@ Expects n8n webhooks at:
 
 ## Changelog
 
+- 2026-03-27: Added alertmanager-ntfy-bridge (parts/ntfy-bridge.nix) — receives Alertmanager webhooks and forwards to ntfy for phone notifications
 - 2026-03-24: Enabled ntfy server (port 2586), integrated with work_lead_response n8n workflow for private lead notifications
 - 2026-02-27: Added ntfy server (migrated from server/native/networking/)
 - 2026-02-26: Created README per Law 12 (migrated from docs/infrastructure/)

--- a/domains/alerts/index.nix
+++ b/domains/alerts/index.nix
@@ -275,7 +275,8 @@ in
   };
 
   imports = [
-    ./parts/server.nix  # ntfy notification server
+    ./parts/server.nix       # ntfy notification server
+    ./parts/ntfy-bridge.nix  # Alertmanager → ntfy bridge
   ];
 
   #==========================================================================

--- a/domains/alerts/parts/ntfy-bridge.nix
+++ b/domains/alerts/parts/ntfy-bridge.nix
@@ -1,0 +1,197 @@
+# domains/alerts/parts/ntfy-bridge.nix
+#
+# Alertmanager → ntfy bridge service
+#
+# Receives Alertmanager webhook POSTs and forwards each alert
+# as a formatted notification to the local ntfy server.
+#
+# NAMESPACE: hwc.alerts.ntfyBridge.*
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hwc.alerts.ntfyBridge;
+  alertsCfg = config.hwc.alerts;
+
+  bridgeScript = pkgs.writers.writePython3 "alertmanager-ntfy-bridge" {
+    flakeIgnore = [ "E501" "W503" ];
+  } ''
+    import json
+    import http.server
+    import urllib.request
+    import sys
+    import os
+    import datetime
+
+    NTFY_URL = sys.argv[1]
+    LISTEN_PORT = int(sys.argv[2])
+    LOG_DIR = "/var/log/hwc/alerts"
+
+    SEVERITY_PRIORITY = {
+        "P5": "5",
+        "P4": "4",
+        "P3": "3",
+    }
+
+    SEVERITY_TAGS = {
+        "P5": "rotating_light",
+        "P4": "warning",
+        "P3": "information_source",
+    }
+
+    STATUS_EMOJI = {
+        "firing": "\U0001f534",
+        "resolved": "\u2705",
+    }
+
+
+    def log(msg):
+        ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        line = f"[{ts}] {msg}"
+        print(line, file=sys.stderr, flush=True)
+        try:
+            os.makedirs(LOG_DIR, exist_ok=True)
+            with open(f"{LOG_DIR}/ntfy-bridge.log", "a") as f:
+                f.write(line + "\n")
+        except Exception:
+            pass
+
+
+    class AlertHandler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+
+            try:
+                data = json.loads(body)
+            except json.JSONDecodeError as e:
+                log(f"Invalid JSON: {e}")
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Invalid JSON")
+                return
+
+            alerts = data.get("alerts", [])
+            log(f"Received {len(alerts)} alert(s)")
+
+            for alert in alerts:
+                try:
+                    self._forward_alert(alert)
+                except Exception as e:
+                    log(f"Failed to forward alert: {e}")
+
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+
+        def _forward_alert(self, alert):
+            labels = alert.get("labels", {})
+            annotations = alert.get("annotations", {})
+            status = alert.get("status", "unknown")
+
+            alertname = labels.get("alertname", "Unknown")
+            severity = labels.get("severity", "P3")
+            instance = labels.get("instance", "")
+            category = labels.get("category", "")
+            summary = annotations.get("summary", alertname)
+            description = annotations.get("description", "")
+
+            emoji = STATUS_EMOJI.get(status, "\u2753")
+
+            if status == "resolved":
+                title = f"{emoji} RESOLVED: {summary}"
+                priority = "2"
+                tags = "white_check_mark"
+            else:
+                title = f"{emoji} {severity}: {summary}"
+                priority = SEVERITY_PRIORITY.get(severity, "3")
+                tags = SEVERITY_TAGS.get(severity, "bell")
+
+            lines = []
+            if description:
+                lines.append(description)
+            if instance:
+                lines.append(f"Instance: {instance}")
+            if category:
+                lines.append(f"Category: {category}")
+            lines.append(f"Status: {status}")
+            message = "\n".join(lines)
+
+            headers = {
+                "Title": title[:256],
+                "Priority": priority,
+                "Tags": tags,
+            }
+
+            req = urllib.request.Request(
+                NTFY_URL,
+                data=message.encode("utf-8"),
+                headers=headers,
+            )
+
+            try:
+                urllib.request.urlopen(req, timeout=10)
+                log(f"Sent {status} alert: {alertname} ({severity})")
+            except Exception as e:
+                log(f"ntfy POST failed for {alertname}: {e}")
+                raise
+
+        def log_message(self, format, *args):
+            log(format % args)
+
+
+    if __name__ == "__main__":
+        server = http.server.HTTPServer(("127.0.0.1", LISTEN_PORT), AlertHandler)
+        log(f"Listening on 127.0.0.1:{LISTEN_PORT}, forwarding to {NTFY_URL}")
+        server.serve_forever()
+  '';
+
+in
+{
+  options.hwc.alerts.ntfyBridge = {
+    enable = lib.mkEnableOption "Alertmanager to ntfy bridge service";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9095;
+      description = "Port for the bridge HTTP server to listen on";
+    };
+
+    ntfyUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://localhost:${toString alertsCfg.server.port}/hwc-alerts";
+      description = "ntfy server URL including topic (e.g., http://localhost:8080/hwc-alerts)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.alertmanager-ntfy-bridge = {
+      description = "Alertmanager to ntfy notification bridge";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${bridgeScript} ${lib.escapeShellArg cfg.ntfyUrl} ${toString cfg.port}";
+        Restart = "always";
+        RestartSec = "5s";
+
+        User = "eric";
+        Group = "users";
+
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/var/log/hwc/alerts" ];
+      };
+    };
+
+    assertions = [
+      {
+        assertion = !cfg.enable || alertsCfg.server.enable;
+        message = "alertmanager-ntfy-bridge requires the ntfy server (hwc.alerts.server.enable = true)";
+      }
+    ];
+  };
+}

--- a/domains/media/frigate/README.md
+++ b/domains/media/frigate/README.md
@@ -671,6 +671,7 @@ hwc.media.frigate = {
 ---
 
 ## Changelog
+- 2026-03-27: Removed broken port 9191:9090 mapping and frigate-nvr scrape config (ignored with --network=host, caused false ServiceDown alerts). Enabled frigate-exporter for proper Prometheus metrics.
 - 2026-03-18: Integrate MQTT support for event publishing, enabling n8n workflows.
 
 - **2026-03-09**: Fixed green tint with substream detection, CUDA hwaccel, go2rtc video=copy

--- a/domains/media/frigate/index.nix
+++ b/domains/media/frigate/index.nix
@@ -224,7 +224,8 @@ LABELMAP_EOF
         "8554:8554"
         "8555:8555/tcp"
         "8555:8555/udp"
-        "9191:9090"
+        # NOTE: 9191:9090 removed — ignored with --network=host and caused
+        # false ServiceDown alerts. Use frigate-exporter module for metrics.
       ];
 
       extraOptions = [
@@ -272,16 +273,8 @@ LABELMAP_EOF
       };
     };
 
-    # Prometheus integration
-    hwc.monitoring.prometheus.scrapeConfigs = [
-      {
-        job_name = "frigate-nvr";
-        static_configs = [{ targets = [ "localhost:9191" ]; }];
-        scrape_interval = "30s";
-        scrape_timeout = "10s";
-        metrics_path = "/metrics";
-      }
-    ];
+    # Prometheus integration: handled by frigate-exporter module (exporter/index.nix)
+    # The frigate container itself does not expose Prometheus metrics natively.
 
     assertions = [
       {

--- a/domains/media/immich-container/README.md
+++ b/domains/media/immich-container/README.md
@@ -79,5 +79,6 @@ journalctl -u immich-machine-learning | grep -i "onnx\|cuda"  # CUDA provider
 
 ## Changelog
 
+- 2026-03-27: Fixed Prometheus metrics port mappings — added host-side port publishing for apiPort (8091) and microservicesPort (8092) which were only set as container env vars but never exposed, causing false ServiceDown alerts
 - 2026-02-26: Created README per Law 12 (migrated from docs/infrastructure/)
 - 2025-11-21: Initial GPU optimization implementation

--- a/domains/media/immich-container/parts/config.nix
+++ b/domains/media/immich-container/parts/config.nix
@@ -159,9 +159,12 @@ in
         "--network-alias=immich-server"
       ];
 
-      ports = lib.optionals (cfg.network.mode != "host") [
+      ports = lib.optionals (cfg.network.mode != "host") ([
         "127.0.0.1:${toString cfg.settings.port}:3001"
-      ];
+      ] ++ lib.optionals cfg.observability.metrics.enable [
+        "127.0.0.1:${toString cfg.observability.metrics.apiPort}:${toString cfg.observability.metrics.apiPort}"
+        "127.0.0.1:${toString cfg.observability.metrics.microservicesPort}:${toString cfg.observability.metrics.microservicesPort}"
+      ]);
 
       environment = {
         IMMICH_PORT = toString cfg.settings.port;

--- a/domains/monitoring/README.md
+++ b/domains/monitoring/README.md
@@ -39,5 +39,6 @@ monitoring/
 
 ## Changelog
 
+- 2026-03-27: Fixed alertmanager routing — default receiver was empty (alerts silently dropped). Now uses child routes with `continue: true` to fan out to all configured webhook receivers. Added ntfy-bridge as second receiver alongside n8n-webhook.
 - 2026-03-04: Namespace migration hwc.server.native.monitoring.* → hwc.monitoring.*
 - 2026-03-04: Moved from domains/server/native/monitoring/ (Phase 4 of DDD migration)

--- a/domains/monitoring/alertmanager/index.nix
+++ b/domains/monitoring/alertmanager/index.nix
@@ -25,7 +25,15 @@ let
       group_wait = cfg.groupWait;
       group_interval = cfg.groupInterval;
       repeat_interval = cfg.repeatInterval;
-      receiver = "default";  # Fallback receiver
+      receiver = "default";
+    } // lib.optionalAttrs (cfg.webhookReceivers != []) {
+      # Fan out to ALL receivers via child routes with continue=true.
+      # Each child matches all alerts and passes them along to the next.
+      routes = map (receiver: {
+        receiver = receiver.name;
+        match_re = { alertname = ".*"; };
+        continue = true;
+      }) cfg.webhookReceivers;
     };
 
     receivers = [

--- a/machines/server/config.nix
+++ b/machines/server/config.nix
@@ -569,6 +569,13 @@
     dataDir = "/var/lib/hwc/ntfy";
   };
 
+  # Alertmanager → ntfy bridge (forwards Prometheus alerts to phone via ntfy)
+  hwc.alerts.ntfyBridge = {
+    enable = true;
+    port = 9095;
+    ntfyUrl = "http://localhost:2586/hwc-alerts";
+  };
+
   # Frigate NVR (Config-First Pattern with GPU Acceleration)
   # Access: https://hwc.ocelot-wahoo.ts.net:5443 (via Caddy)
   # Charter v7.0 Section 19 compliant - TensorRT CUDA support
@@ -593,6 +600,9 @@
 
     # Firewall settings
     firewall.tailscaleOnly = true;
+
+    # Prometheus metrics exporter (polls /api/stats, serves /metrics on port 9192)
+    exporter.enable = true;
   };
 
   # Automated surveillance cleanup (enforce Frigate retention policy)

--- a/night2_audit.md
+++ b/night2_audit.md
@@ -1,0 +1,97 @@
+# Night 2 Audit Report — Notification Landscape
+
+**Date**: 2026-03-27
+**Auditor**: Claude (automated)
+
+## 1. Current Notification Channels
+
+### Slack (via n8n webhooks)
+- **Service failure notifier**: `hwc-service-failure-notifier@` systemd template — triggers on `OnFailure=` for 16 critical services, sends to Slack via `hwc-service-failure-notify` script
+- **Alertmanager → n8n**: Webhook receiver at `https://hwc.ocelot-wahoo.ts.net:2443/webhook/alertmanager` — receives all Prometheus alerts, presumably routes to Slack
+- **Backup notifications**: `hwc-backup-notify` sends to Slack webhook
+- **Disk space checks**: `hwc-disk-space-check` hourly timer, sends to Slack webhook
+- **SMART disk alerts**: `hwc-smartd-notify` hooks into smartd, sends to Slack webhook
+- **Webhook health check**: Runs every 15 minutes to verify n8n endpoint is reachable
+
+### ntfy (partially configured)
+- **ntfy server**: Container on port 8080, exposed via Tailscale HTTPS at `https://hwc.ocelot-wahoo.ts.net:2586`
+- **ntfy CLI tool**: `hwc-ntfy-send` installed system-wide, configured for `ntfy.sh` with default topic `hwc-alerts`
+- **Backup integration**: Local backup script calls `hwc-ntfy-send` on success/failure
+- **NOT wired to Alertmanager**: No bridge exists between Alertmanager and ntfy
+
+## 2. Alertmanager Configuration
+
+- **Port**: 9093
+- **Receivers**: 1 webhook receiver → n8n (`n8n-webhook`)
+- **Default receiver**: `default` (empty — alerts matching no route are silently dropped)
+- **Route**: Groups by `alertname, cluster, service`; 30s wait, 5m interval, 4h repeat
+- **Problem**: Default receiver is empty. Only `n8n-webhook` receiver is configured but the route sends to `default`, not `n8n-webhook`!
+
+## 3. Prometheus Alert Rules
+
+### P5 — Critical (6 rules)
+- HighCPUUsage (>90% for 10m)
+- HighMemoryUsage (>95% for 10m)
+- HighDiskUsage (>95% for 15m, root only)
+- **ServiceDown** (`up == 0` for 5m) — catches any scrape target that's unreachable
+- FrigateCameraOffline (fps < 1 for 5m)
+- ImmichHighErrorRate (>10 errors/sec for 10m)
+
+### P4 — Warning (7 rules)
+- ElevatedCPUUsage (>70%), ElevatedMemoryUsage (>80%), ElevatedDiskUsage (>85%)
+- FrigateLowFPS, FrigateHighCPU, ImmichLargeQueue, ContainerHighMemory
+
+### P3 — Info (4 rules)
+- **ModerateDiskUsage** (>75% for 1h) — likely legitimate
+- FrigateDetectionSpike, ImmichSlowAPI, HighNetworkTraffic
+
+## 4. Currently Firing Alerts (4 stale since ~Mar 13)
+
+### ServiceDown — immich-api (localhost:8091)
+**Root cause**: Immich container uses `media` podman network. Port 8091 is set as `IMMICH_API_METRICS_PORT` env var inside the container but **never mapped to the host**. Only port 2283:3001 is published.
+**Fix**: Add `"127.0.0.1:8091:8091"` port mapping to immich-server container.
+
+### ServiceDown — immich-workers (localhost:8092)
+**Root cause**: Same as above — port 8092 (`IMMICH_MICROSERVICES_METRICS_PORT`) is never mapped to the host.
+**Fix**: Add `"127.0.0.1:8092:8092"` port mapping to immich-server container.
+
+### ServiceDown — frigate-nvr (localhost:9191)
+**Root cause**: Frigate container uses `--network=host` mode. The port mapping `"9191:9090"` is **ignored** when using host networking — container ports bind directly to the host. Port 9090 inside the container (if it exists) would conflict with Prometheus on the host. The scrape config targets `localhost:9191` which doesn't exist.
+Additionally, there's a **separate** `frigate-exporter` container (port 9192) that properly exports Frigate metrics. The `frigate-nvr` scrape job in `frigate/index.nix` is redundant.
+**Fix**: Remove the broken `9191:9090` port mapping and the `frigate-nvr` scrape config from `frigate/index.nix`. The `frigate-exporter` at port 9192 already handles metrics correctly.
+
+### ModerateDiskUsage — node
+**Root cause**: Likely legitimate — disk usage >75% on some mountpoint. This is an info-level (P3) alert. Not a false positive, just noisy.
+**Assessment**: No code change needed. Once ntfy is wired, Eric can evaluate whether 75% threshold is appropriate.
+
+## 5. Alertmanager Routing Bug
+
+The alertmanager config has a critical routing issue:
+```
+route.receiver = "default"   # ← empty receiver, drops all alerts!
+```
+The `n8n-webhook` receiver is defined but never referenced in routing. All alerts go to `default` (which has no webhook_configs), so **no alerts are actually delivered anywhere**.
+
+**Fix**: Change the default receiver to `n8n-webhook`, or add explicit route matching.
+
+## 6. ntfy Infrastructure Status
+
+- ntfy server container: Running on port 8080, Tailscale-exposed on port 2586
+- ntfy CLI (`hwc-ntfy-send`): Functional, used by backup scripts
+- **Missing**: Alertmanager → ntfy bridge (no translation layer exists)
+- **Missing**: Alert routing to ntfy topic
+
+## 7. n8n Workflows (investigation needed at runtime)
+
+- `sys_alertmanager_router` — likely receives Alertmanager webhooks and routes to Slack
+- `Cross-Service Health Monitor` — likely does HTTP health checks
+- Both updated Mar 25, suggesting recent maintenance
+- Cannot inspect workflow details without runtime access to n8n API
+
+## 8. Recommendations
+
+1. **Create alertmanager-ntfy-bridge**: Small Python HTTP service that receives Alertmanager webhooks and forwards to ntfy
+2. **Fix alertmanager routing**: Change default receiver to `n8n-webhook` so alerts actually get delivered
+3. **Add ntfy as second receiver**: Keep Slack delivery via n8n, add ntfy bridge as additional receiver
+4. **Fix stale alerts**: Map immich metrics ports, remove broken frigate scrape config
+5. **Test end-to-end**: Fire a test alert through Alertmanager and verify ntfy delivery

--- a/night2_report.md
+++ b/night2_report.md
@@ -1,0 +1,138 @@
+# Night 2 Report — Alerting Pipeline to ntfy + Stale Alert Fixes
+
+**Date**: 2026-03-27
+**Branch**: `claude/alertmanager-ntfy-bridge-aniQp`
+
+## Summary
+
+Wired the existing Prometheus/Alertmanager monitoring stack to deliver alerts to Eric's phone via ntfy. Fixed 3 false-positive ServiceDown alerts that had been firing since March 13. Fixed a critical alertmanager routing bug where ALL alerts were silently dropped.
+
+## Changes Made
+
+### 1. Alertmanager → ntfy Bridge (NEW)
+
+**File**: `domains/alerts/parts/ntfy-bridge.nix`
+
+Created a lightweight Python HTTP service that:
+- Listens on `localhost:9095`
+- Receives Alertmanager webhook POSTs (JSON)
+- Translates each alert into a formatted ntfy notification
+- Maps severity (P5/P4/P3) to ntfy priority levels (5/4/3)
+- Sends resolved alerts at low priority with checkmark emoji
+- Logs to `/var/log/hwc/alerts/ntfy-bridge.log`
+- Runs as `eric:users` with systemd hardening
+
+**Enabled in**: `machines/server/config.nix` → `hwc.alerts.ntfyBridge.enable = true`
+
+### 2. Alertmanager Routing Fix (BUG FIX — CRITICAL)
+
+**File**: `domains/monitoring/alertmanager/index.nix`
+
+**Bug**: The default receiver was `"default"` which had no webhook_configs. ALL Prometheus alerts were silently dropped. The n8n-webhook receiver was defined but never referenced in any route.
+
+**Fix**: Changed routing to use child routes with `continue: true` so alerts fan out to ALL configured webhook receivers (n8n-webhook AND ntfy-bridge).
+
+### 3. ntfy Bridge Added as Second Alertmanager Receiver
+
+**File**: `profiles/monitoring.nix`
+
+Added `ntfy-bridge` (http://localhost:9095) alongside existing `n8n-webhook` receiver. Both receivers get all alerts. Slack delivery via n8n is preserved.
+
+### 4. Immich Metrics Port Fix (3→0 false ServiceDown alerts)
+
+**File**: `domains/media/immich-container/parts/config.nix`
+
+**Bug**: Immich metrics ports 8091 (API) and 8092 (microservices) were set as container env vars but never published to the host. The container runs on `media` podman network — only port 2283 was mapped. Prometheus scraped `localhost:8091` and `localhost:8092` which didn't exist on the host.
+
+**Fix**: Added port mappings `127.0.0.1:8091:8091` and `127.0.0.1:8092:8092` to the immich-server container, conditional on metrics being enabled.
+
+### 5. Frigate Scrape Config Fix (1→0 false ServiceDown alerts)
+
+**File**: `domains/media/frigate/index.nix`
+
+**Bug**: Frigate container uses `--network=host`. Port mappings are ignored with host networking. The mapping `9191:9090` was silently ignored, so `localhost:9191` didn't exist. Additionally, Frigate doesn't natively export Prometheus metrics — that's what the separate `frigate-exporter` container is for.
+
+**Fix**:
+- Removed broken `9191:9090` port mapping
+- Removed broken `frigate-nvr` Prometheus scrape config
+- Enabled `hwc.media.frigate.exporter` in server config (port 9192, proper Prometheus metrics)
+
+### 6. Frigate Exporter Enabled
+
+**File**: `machines/server/config.nix`
+
+Added `exporter.enable = true` to frigate config. The exporter container polls Frigate's `/api/stats` API and serves Prometheus-format metrics on port 9192.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `domains/alerts/parts/ntfy-bridge.nix` | **NEW** — Alertmanager → ntfy bridge service |
+| `domains/alerts/index.nix` | Import ntfy-bridge module |
+| `domains/monitoring/alertmanager/index.nix` | Fix routing: fan out to all receivers via child routes |
+| `profiles/monitoring.nix` | Add ntfy-bridge as second webhook receiver |
+| `machines/server/config.nix` | Enable ntfy bridge + frigate exporter |
+| `domains/media/immich-container/parts/config.nix` | Publish metrics ports 8091/8092 to host |
+| `domains/media/frigate/index.nix` | Remove broken port mapping + scrape config |
+| `domains/alerts/README.md` | Updated structure + changelog |
+| `domains/monitoring/README.md` | Updated changelog |
+| `domains/media/frigate/README.md` | Updated changelog |
+| `domains/media/immich-container/README.md` | Updated changelog |
+| `night2_audit.md` | Full audit of notification landscape |
+
+## What Was NOT Changed
+
+- Prometheus alert rules (thresholds unchanged)
+- Grafana dashboards
+- Existing Slack/n8n notification path (preserved as-is)
+- n8n workflows (not touched)
+- No `nixos-rebuild switch` was run
+
+## Eric's Action Items
+
+### Before Applying
+
+1. **Run `nix flake check`** — nix was not available in the CI environment
+2. **Review the alertmanager routing change** — this was a silent bug; all Prometheus alerts have been silently dropped since alertmanager was configured
+3. **Consider the ModerateDiskUsage alert** — P3 at 75% threshold. Decide if this is noise or useful once ntfy is delivering
+
+### After `nixos-rebuild switch`
+
+4. **Test ntfy delivery**:
+   ```bash
+   # Direct ntfy test
+   curl -d "Night 2 test — alerting pipeline working" \
+     -H "Title: Test Alert" -H "Tags: test_tube" \
+     http://localhost:2586/hwc-alerts
+
+   # Alertmanager → ntfy bridge test
+   curl -X POST http://localhost:9093/api/v2/alerts \
+     -H "Content-Type: application/json" \
+     -d '[{"labels":{"alertname":"TestAlert","severity":"P3"},"annotations":{"summary":"Night 2 ntfy bridge test"},"startsAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}]'
+   ```
+
+5. **Verify stale alerts cleared**:
+   ```bash
+   curl -s http://localhost:9090/api/v1/alerts | python3 -c "
+   import json, sys
+   data = json.load(sys.stdin)
+   firing = [a for a in data['data']['alerts'] if a['state'] == 'firing']
+   print(f'{len(firing)} alerts still firing')
+   for a in firing:
+       print(f\"  {a['labels'].get('alertname')}: {a['labels'].get('instance')}\")
+   "
+   ```
+
+6. **Check bridge service**:
+   ```bash
+   systemctl status alertmanager-ntfy-bridge
+   journalctl -u alertmanager-ntfy-bridge -f
+   ```
+
+7. **Subscribe to ntfy topic on phone**: Open ntfy app → subscribe to `hwc-alerts` on `https://hwc.ocelot-wahoo.ts.net:2586`
+
+### Optional Enhancements
+
+- Adjust ModerateDiskUsage threshold (75% → 80%?) if too noisy
+- Add more scrape targets for services like heartwood-mcp (:6100), estimator-api (:8099)
+- Consider adding state-change-only tracking in the bridge to avoid repeat notifications (Alertmanager's `repeat_interval: 4h` handles this partially)

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -49,6 +49,11 @@
         url = "https://hwc.ocelot-wahoo.ts.net:2443/webhook/alertmanager";
         sendResolved = true;
       }
+      {
+        name = "ntfy-bridge";
+        url = "http://localhost:9095";
+        sendResolved = true;
+      }
     ];
   };
 


### PR DESCRIPTION
Add alertmanager-ntfy-bridge service that receives Alertmanager webhooks
and forwards formatted notifications to ntfy (phone push). Fix critical
routing bug where all Prometheus alerts were silently dropped (default
receiver was empty). Fix 3 false ServiceDown alerts firing since Mar 13:
immich metrics ports not published to host, frigate scrape config broken
by --network=host ignoring port mappings.

https://claude.ai/code/session_01TyPp9wTZkvQZWQNFvrR4dw