### PR TITLE
Add "New Customer" mode to estimator

### DIFF
--- a/domains/automation/n8n/parts/workflows/08b-estimate-router.json
+++ b/domains/automation/n8n/parts/workflows/08b-estimate-router.json
@@ -17,7 +17,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Validate x-api-key header\nconst apiKey = $input.item.json.headers['x-api-key'];\nconst expectedKey = $env.ESTIMATOR_API_KEY;\n\nif (!apiKey || apiKey !== expectedKey) {\n  throw new Error('UNAUTHORIZED');\n}\n\nconst body = $input.item.json.body;\n\n// Validate required fields\nif (!body.action || body.action !== 'push_estimate') {\n  throw new Error('Invalid action');\n}\n\nif (!body.jtPayload || !Array.isArray(body.jtPayload) || body.jtPayload.length === 0) {\n  throw new Error('jtPayload is required and must be a non-empty array');\n}\n\n// Determine job mode\nconst isNewJob = body.mode === 'new_job';\n\nif (isNewJob) {\n  if (!body.newJob || !body.newJob.customerId) {\n    throw new Error('newJob.customerId is required for new jobs');\n  }\n} else {\n  if (!body.jobId) {\n    throw new Error('jobId is required for existing jobs');\n  }\n}\n\nreturn {\n  json: {\n    // Job identification\n    mode: body.mode || 'existing',\n    jobId: body.jobId || null,\n    jobNumber: body.jobNumber || null,\n    jobName: body.jobName || null,\n    customerId: body.customerId || body.newJob?.customerId || null,\n    customerName: body.customerName || body.newJob?.customerName || null,\n    projectType: body.projectType || 'general',\n    \n    // For new job creation\n    newJob: body.newJob || null,\n    \n    // Payload data\n    projectState: body.projectState || {},\n    jtPayload: body.jtPayload,\n    totals: body.totals || {},\n    \n    // Metadata\n    timestamp: body.timestamp || new Date().toISOString(),\n    requestId: `est-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`\n  }\n};"
+        "jsCode": "// Validate x-api-key header\nconst apiKey = $input.item.json.headers['x-api-key'];\nconst expectedKey = $env.ESTIMATOR_API_KEY;\n\nif (!apiKey || apiKey !== expectedKey) {\n  throw new Error('UNAUTHORIZED');\n}\n\nconst body = $input.item.json.body;\n\n// Validate required fields\nif (!body.action || body.action !== 'push_estimate') {\n  throw new Error('Invalid action');\n}\n\nif (!body.jtPayload || !Array.isArray(body.jtPayload) || body.jtPayload.length === 0) {\n  throw new Error('jtPayload is required and must be a non-empty array');\n}\n\n// Validate per mode\nif (body.mode === 'new_customer') {\n  if (!body.newCustomer || !body.newCustomer.name) {\n    throw new Error('newCustomer.name is required for new customers');\n  }\n} else if (body.mode === 'new_job') {\n  if (!body.newJob || !body.newJob.customerId) {\n    throw new Error('newJob.customerId is required for new jobs');\n  }\n} else {\n  if (!body.jobId) {\n    throw new Error('jobId is required for existing jobs');\n  }\n}\n\nreturn {\n  json: {\n    // Job identification\n    mode: body.mode || 'existing',\n    jobId: body.jobId || null,\n    jobNumber: body.jobNumber || null,\n    jobName: body.jobName || null,\n    customerId: body.customerId || body.newJob?.customerId || null,\n    customerName: body.customerName || body.newJob?.customerName || body.newCustomer?.name || null,\n    projectType: body.projectType || 'general',\n    \n    // For new job creation\n    newJob: body.newJob || null,\n    \n    // For new customer creation\n    newCustomer: body.newCustomer || null,\n    \n    // Payload data\n    projectState: body.projectState || {},\n    jtPayload: body.jtPayload,\n    totals: body.totals || {},\n    \n    // Metadata\n    timestamp: body.timestamp || new Date().toISOString(),\n    requestId: `est-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`\n  }\n};"
       },
       "id": "validate-request",
       "name": "Validate Request",
@@ -37,10 +37,10 @@
             {
               "id": "new-job-check",
               "leftValue": "={{ $json.mode }}",
-              "rightValue": "new_job",
+              "rightValue": "existing",
               "operator": {
                 "type": "string",
-                "operation": "equals"
+                "operation": "notEquals"
               }
             }
           ],
@@ -71,7 +71,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Extract created job details from Pave response\nconst response = $input.item.json;\nconst prevData = $('Validate Request').item.json;\n\nif (response.errors && response.errors.length > 0) {\n  throw new Error(`JT job creation failed: ${response.errors[0].message}`);\n}\n\nconst createdJob = response.createJob;\n\nif (!createdJob || !createdJob.id) {\n  throw new Error('JT job creation returned no job ID');\n}\n\nreturn {\n  json: {\n    ...prevData,\n    jobId: createdJob.id,\n    jobNumber: createdJob.number,\n    jobName: createdJob.name,\n    jobCreated: true\n  }\n};"
+        "jsCode": "// Extract created job details from Pave response\nconst response = $input.item.json;\nconst prevData = $('Validate Request').item.json;\n\nif (response.errors && response.errors.length > 0) {\n  throw new Error(`JT job creation failed: ${response.errors[0].message}`);\n}\n\nconst createdJob = response.createJob;\n\nif (!createdJob || !createdJob.id) {\n  throw new Error('JT job creation returned no job ID');\n}\n\nreturn {\n  json: {\n    ...prevData,\n    jobId: createdJob.id,\n    jobNumber: createdJob.number,\n    jobName: createdJob.name,\n    jobCreated: true,\n    accountCreated: false\n  }\n};"
       },
       "id": "parse-created-job",
       "name": "Parse Created Job",
@@ -205,7 +205,7 @@
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={\n  \"success\": true,\n  \"jtPushSuccess\": {{ $json.jtPushSuccess }},\n  \"jtPushError\": {{ JSON.stringify($json.jtPushError) }},\n  \"jobId\": {{ JSON.stringify($json.jobId) }},\n  \"jobNumber\": {{ JSON.stringify($json.jobNumber) }},\n  \"jobCreated\": {{ $json.jobCreated || false }},\n  \"itemsPushed\": {{ $json.itemsPushed || 0 }},\n  \"archived\": true,\n  \"requestId\": {{ JSON.stringify($json.requestId) }}\n}"
+        "responseBody": "={\n  \"success\": true,\n  \"jtPushSuccess\": {{ $json.jtPushSuccess }},\n  \"jtPushError\": {{ JSON.stringify($json.jtPushError) }},\n  \"jobId\": {{ JSON.stringify($json.jobId) }},\n  \"jobNumber\": {{ JSON.stringify($json.jobNumber) }},\n  \"jobCreated\": {{ $json.jobCreated || false }},\n  \"accountCreated\": {{ $json.accountCreated || false }},\n  \"customerId\": {{ JSON.stringify($json.customerId) }},\n  \"itemsPushed\": {{ $json.itemsPushed || 0 }},\n  \"archived\": true,\n  \"requestId\": {{ JSON.stringify($json.requestId) }}\n}"
       },
       "id": "respond-success",
       "name": "Respond Success",
@@ -240,6 +240,96 @@
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
       "position": [680, 620]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "new-customer-check",
+              "leftValue": "={{ $json.mode }}",
+              "rightValue": "new_customer",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "is-new-customer",
+      "name": "Is New Customer?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [900, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.jobtread.com/pave",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"query\": {\n    \"$\": { \"grantKey\": \"{{ $env.JOBTREAD_GRANT_KEY }}\" },\n    \"createAccount\": {\n      \"$\": {\n        \"name\": \"{{ $json.newCustomer.name }}\",\n        \"type\": \"customer\",\n        \"organizationId\": \"22Nm3uFevXMb\"\n      },\n      \"createdAccount\": {\n        \"id\": {},\n        \"name\": {},\n        \"type\": {}\n      }\n    }\n  }\n}",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "create-jt-account",
+      "name": "Create JT Account",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1120, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.jobtread.com/pave",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"query\": {\n    \"$\": { \"grantKey\": \"{{ $env.JOBTREAD_GRANT_KEY }}\" },\n    \"createLocation\": {\n      \"$\": {\n        \"accountId\": \"{{ $json.createAccount.createdAccount.id }}\",\n        \"name\": \"Primary\",\n        \"address\": {\n          \"street1\": \"{{ $('Validate Request').item.json.newCustomer.street || '' }}\",\n          \"city\": \"{{ $('Validate Request').item.json.newCustomer.city || '' }}\",\n          \"state\": \"{{ $('Validate Request').item.json.newCustomer.state || '' }}\",\n          \"zip\": \"{{ $('Validate Request').item.json.newCustomer.zip || '' }}\"\n        }\n      },\n      \"createdLocation\": {\n        \"id\": {}\n      }\n    }\n  }\n}",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "create-jt-location",
+      "name": "Create JT Location",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1340, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.jobtread.com/pave",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"query\": {\n    \"$\": { \"grantKey\": \"{{ $env.JOBTREAD_GRANT_KEY }}\" },\n    \"createJob\": {\n      \"$\": {\n        \"locationId\": \"{{ $json.createLocation.createdLocation.id }}\",\n        \"name\": \"{{ $('Validate Request').item.json.jobName }}\"\n      },\n      \"id\": {},\n      \"number\": {},\n      \"name\": {}\n    }\n  }\n}",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "create-job-new-customer",
+      "name": "Create Job (New Customer)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [1560, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Normalize new customer job data for Merge Job Data\nconst response = $input.item.json;\nconst prevData = $('Validate Request').item.json;\nconst accountId = $('Create JT Account').item.json.createAccount.createdAccount.id;\nconst locationId = $('Create JT Location').item.json.createLocation.createdLocation.id;\n\nif (response.errors && response.errors.length > 0) {\n  throw new Error(`JT job creation failed: ${response.errors[0].message}`);\n}\n\nconst createdJob = response.createJob;\nif (!createdJob || !createdJob.id) {\n  throw new Error('JT job creation for new customer returned no job ID');\n}\n\nreturn {\n  json: {\n    ...prevData,\n    customerId: accountId,\n    locationId: locationId,\n    customerName: prevData.newCustomer.name,\n    jobId: createdJob.id,\n    jobNumber: createdJob.number,\n    jobName: createdJob.name,\n    jobCreated: true,\n    accountCreated: true\n  }\n};"
+      },
+      "id": "parse-new-customer-job",
+      "name": "Parse New Customer Job",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1780, 0]
     }
   ],
   "connections": {
@@ -251,9 +341,27 @@
     },
     "Is New Job?": {
       "main": [
-        [{ "node": "Create JT Job", "type": "main", "index": 0 }],
+        [{ "node": "Is New Customer?", "type": "main", "index": 0 }],
         [{ "node": "Use Existing Job", "type": "main", "index": 0 }]
       ]
+    },
+    "Is New Customer?": {
+      "main": [
+        [{ "node": "Create JT Account", "type": "main", "index": 0 }],
+        [{ "node": "Create JT Job", "type": "main", "index": 0 }]
+      ]
+    },
+    "Create JT Account": {
+      "main": [[{ "node": "Create JT Location", "type": "main", "index": 0 }]]
+    },
+    "Create JT Location": {
+      "main": [[{ "node": "Create Job (New Customer)", "type": "main", "index": 0 }]]
+    },
+    "Create Job (New Customer)": {
+      "main": [[{ "node": "Parse New Customer Job", "type": "main", "index": 0 }]]
+    },
+    "Parse New Customer Job": {
+      "main": [[{ "node": "Merge Job Data", "type": "main", "index": 0 }]]
     },
     "Create JT Job": {
       "main": [[{ "node": "Parse Created Job", "type": "main", "index": 0 }]]

--- a/domains/business/estimator/app/src/components/EstimateTab.jsx
+++ b/domains/business/estimator/app/src/components/EstimateTab.jsx
@@ -54,10 +54,10 @@ export function EstimateTab({ groups, totals, overrides, setOverrides, removed, 
 
   const canPush = () => {
     if (!state) return false;
-    if (!state.customerId) return false;
-    if (state.mode === 'existing' && !state.jobId) return false;
-    if (state.mode === 'new_job' && !state.jobName) return false;
-    return true;
+    if (state.mode === 'existing') return !!state.customerId && !!state.jobId;
+    if (state.mode === 'new_job') return !!state.customerId && !!state.jobName;
+    if (state.mode === 'new_customer') return !!state.newCustomerName && !!state.jobName;
+    return false;
   };
 
   const pushToWebhook = async () => {
@@ -78,16 +78,27 @@ export function EstimateTab({ groups, totals, overrides, setOverrides, removed, 
         jobId: state.jobId || null,
         jobNumber: state.jobNumber || null,
         jobName: state.jobName || null,
-        customerId: state.customerId,
-        customerName: state.customerName,
+        customerId: state.customerId || null,
+        customerName: state.customerName || state.newCustomerName || null,
 
-        // For new job creation
-        newJob: state.mode === 'new_job' ? {
-          customerId: state.customerId,
-          customerName: state.customerName,
-          locationId: state.locationId,
+        // For new job creation (new_job and new_customer both need a new job)
+        newJob: (state.mode === 'new_job' || state.mode === 'new_customer') ? {
+          customerId: state.customerId || null,
+          customerName: state.customerName || state.newCustomerName,
+          locationId: state.locationId || null,
           jobName: state.jobName,
-          address: state.address,
+          address: state.address || '',
+        } : null,
+
+        // For new customer creation
+        newCustomer: state.mode === 'new_customer' ? {
+          name: state.newCustomerName,
+          phone: state.newCustomerPhone,
+          email: state.newCustomerEmail,
+          street: state.newCustomerStreet,
+          city: state.newCustomerCity,
+          state: state.newCustomerState,
+          zip: state.newCustomerZip,
         } : null,
 
         // JT parameters array — pushed to createJob
@@ -327,7 +338,7 @@ export function EstimateTab({ groups, totals, overrides, setOverrides, removed, 
       {/* Status messages */}
       {pushMsg === 'no-url' && <StatusBox>No webhook URL. Set <code>VITE_WEBHOOK_URL</code> or localStorage.</StatusBox>}
       {pushMsg === 'no-key' && <StatusBox>No API key. Set <code>VITE_API_KEY</code> or localStorage.</StatusBox>}
-      {pushMsg === 'no-job' && <StatusBox>Select a customer and job in Scope tab before pushing.</StatusBox>}
+      {pushMsg === 'no-job' && <StatusBox>Select a job, or fill in new job/customer details in Scope tab.</StatusBox>}
 
       {pushResult && (
         <div style={{
@@ -340,6 +351,7 @@ export function EstimateTab({ groups, totals, overrides, setOverrides, removed, 
               <div style={{ fontWeight: 600, marginBottom: 4 }}>Pushed to JobTread</div>
               <div style={{ color: C.tx }}>
                 Job #{pushResult.jobNumber} · {pushResult.itemsPushed} items
+                {pushResult.accountCreated && ' · New customer created'}
                 {pushResult.jobCreated && ' · New job created'}
               </div>
             </div>

--- a/domains/business/estimator/app/src/components/JobSelector.jsx
+++ b/domains/business/estimator/app/src/components/JobSelector.jsx
@@ -103,7 +103,36 @@ export function JobSelector({ s, set }) {
     set('jobName', job?.name || '');
   }, [jobs, set]);
 
-  const isNewJob = s.mode === 'new_job';
+  const handleModeChange = useCallback((newMode) => {
+    const oldMode = s.mode;
+    if (newMode === oldMode) return;
+
+    set('jobId', '');
+    set('jobNumber', '');
+
+    if (newMode === 'new_customer') {
+      set('customerId', '');
+      set('customerName', '');
+      set('locationId', '');
+      set('address', '');
+      set('jobName', '');
+    }
+
+    if (oldMode === 'new_customer') {
+      set('newCustomerName', '');
+      set('newCustomerPhone', '');
+      set('newCustomerEmail', '');
+      set('newCustomerStreet', '');
+      set('newCustomerCity', '');
+      set('newCustomerState', 'MT');
+      set('newCustomerZip', '');
+      set('jobName', '');
+    }
+
+    set('mode', newMode);
+  }, [s.mode, set]);
+
+  const isNewCustomer = s.mode === 'new_customer';
 
   // Show config warning if no API configured
   if (!API_BASE || !API_KEY) {
@@ -136,51 +165,50 @@ export function JobSelector({ s, set }) {
 
       {/* Mode toggle */}
       <div style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
-        <button
-          onClick={() => set('mode', 'existing')}
-          style={{
-            flex: 1, padding: '12px 12px', borderRadius: 6, cursor: 'pointer',
-            border: `1px solid ${!isNewJob ? C.acc : C.brd}`,
-            backgroundColor: !isNewJob ? 'rgba(201,149,107,0.15)' : 'transparent',
-            color: !isNewJob ? C.acc : C.txD,
-            fontSize: 12, fontWeight: 600, fontFamily: mono,
-            minHeight: 48,
-          }}
-        >
-          Existing Job
-        </button>
-        <button
-          onClick={() => set('mode', 'new_job')}
-          style={{
-            flex: 1, padding: '12px 12px', borderRadius: 6, cursor: 'pointer',
-            border: `1px solid ${isNewJob ? C.acc : C.brd}`,
-            backgroundColor: isNewJob ? 'rgba(201,149,107,0.15)' : 'transparent',
-            color: isNewJob ? C.acc : C.txD,
-            fontSize: 12, fontWeight: 600, fontFamily: mono,
-            minHeight: 48,
-          }}
-        >
-          New Job
-        </button>
+        {[
+          { id: 'existing', label: 'Existing Job' },
+          { id: 'new_job', label: 'New Job' },
+          { id: 'new_customer', label: 'New Customer' },
+        ].map(m => {
+          const active = s.mode === m.id;
+          return (
+            <button
+              key={m.id}
+              onClick={() => handleModeChange(m.id)}
+              style={{
+                flex: 1, padding: '12px 8px', borderRadius: 6, cursor: 'pointer',
+                border: `1px solid ${active ? C.acc : C.brd}`,
+                backgroundColor: active ? 'rgba(201,149,107,0.15)' : 'transparent',
+                color: active ? C.acc : C.txD,
+                fontSize: 11, fontWeight: 600, fontFamily: mono,
+                minHeight: 48,
+              }}
+            >
+              {m.label}
+            </button>
+          );
+        })}
       </div>
 
-      {/* Customer dropdown */}
-      <FieldRow label="Customer">
-        <select
-          value={s.customerId}
-          onChange={e => handleCustomerChange(e.target.value)}
-          disabled={loading.customers}
-          style={selectStyle}
-        >
-          <option value="">{loading.customers ? 'Loading...' : '— Select Customer —'}</option>
-          {customers.map(c => (
-            <option key={c.id} value={c.id}>{c.name}</option>
-          ))}
-        </select>
-      </FieldRow>
+      {/* Customer dropdown (existing + new_job modes) */}
+      {!isNewCustomer && (
+        <FieldRow label="Customer">
+          <select
+            value={s.customerId}
+            onChange={e => handleCustomerChange(e.target.value)}
+            disabled={loading.customers}
+            style={selectStyle}
+          >
+            <option value="">{loading.customers ? 'Loading...' : '— Select Customer —'}</option>
+            {customers.map(c => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </FieldRow>
+      )}
 
       {/* Existing job mode: job dropdown */}
-      {!isNewJob && s.customerId && (
+      {s.mode === 'existing' && s.customerId && (
         <FieldRow label="Job">
           <select
             value={s.jobId}
@@ -197,7 +225,7 @@ export function JobSelector({ s, set }) {
       )}
 
       {/* New job mode: job name + address inputs */}
-      {isNewJob && s.customerId && (
+      {s.mode === 'new_job' && s.customerId && (
         <>
           <FieldRow label="Job Name">
             <input
@@ -220,6 +248,88 @@ export function JobSelector({ s, set }) {
         </>
       )}
 
+      {/* New customer mode: customer info + job name */}
+      {isNewCustomer && (
+        <>
+          <FieldRow label="Name *">
+            <input
+              type="text"
+              value={s.newCustomerName}
+              onChange={e => set('newCustomerName', e.target.value)}
+              placeholder="Customer name"
+              style={inputStyle}
+            />
+          </FieldRow>
+          <FieldRow label="Phone">
+            <input
+              type="tel"
+              value={s.newCustomerPhone}
+              onChange={e => set('newCustomerPhone', e.target.value)}
+              placeholder="(406) 555-1234"
+              style={inputStyle}
+            />
+          </FieldRow>
+          <FieldRow label="Email">
+            <input
+              type="email"
+              value={s.newCustomerEmail}
+              onChange={e => set('newCustomerEmail', e.target.value)}
+              placeholder="email@example.com"
+              style={inputStyle}
+            />
+          </FieldRow>
+          <FieldRow label="Street">
+            <input
+              type="text"
+              value={s.newCustomerStreet}
+              onChange={e => set('newCustomerStreet', e.target.value)}
+              placeholder="123 Main St"
+              style={inputStyle}
+            />
+          </FieldRow>
+          <div style={{ display: 'flex', gap: 8, padding: '5px 0' }}>
+            <div style={{ flex: 2 }}>
+              <input
+                type="text"
+                value={s.newCustomerCity}
+                onChange={e => set('newCustomerCity', e.target.value)}
+                placeholder="City"
+                style={inputStyle}
+              />
+            </div>
+            <div style={{ flex: 0.7 }}>
+              <input
+                type="text"
+                value={s.newCustomerState}
+                onChange={e => set('newCustomerState', e.target.value)}
+                placeholder="ST"
+                maxLength={2}
+                style={{ ...inputStyle, textAlign: 'center' }}
+              />
+            </div>
+            <div style={{ flex: 1 }}>
+              <input
+                type="text"
+                value={s.newCustomerZip}
+                onChange={e => set('newCustomerZip', e.target.value)}
+                placeholder="Zip"
+                style={inputStyle}
+              />
+            </div>
+          </div>
+          <Divider />
+          <FieldRow label="Job Name *">
+            <input
+              type="text"
+              value={s.jobName}
+              onChange={e => set('jobName', e.target.value)}
+              placeholder="e.g. Master Bath Remodel"
+              style={inputStyle}
+            />
+          </FieldRow>
+        </>
+      )}
+
       {/* Project type */}
       <Divider />
       <Select
@@ -235,13 +345,25 @@ export function JobSelector({ s, set }) {
       />
 
       {/* Selected job summary */}
-      {s.jobId && !isNewJob && (
+      {s.mode === 'existing' && s.jobId && (
         <div style={{ marginTop: 10, padding: 10, backgroundColor: C.card2, borderRadius: 5 }}>
           <div style={{ fontSize: 10, color: C.txD, marginBottom: 4 }}>Selected Job</div>
           <div style={{ fontSize: 12, color: C.acc, fontWeight: 600 }}>
             #{s.jobNumber} — {s.jobName}
           </div>
           <div style={{ fontSize: 11, color: C.tx }}>{s.customerName}</div>
+        </div>
+      )}
+
+      {/* New customer summary */}
+      {isNewCustomer && s.newCustomerName && (
+        <div style={{ marginTop: 10, padding: 10, backgroundColor: C.card2, borderRadius: 5 }}>
+          <div style={{ fontSize: 10, color: C.txD, marginBottom: 4 }}>New Customer</div>
+          <div style={{ fontSize: 12, color: C.acc, fontWeight: 600 }}>
+            {s.newCustomerName}
+          </div>
+          {s.jobName && <div style={{ fontSize: 11, color: C.tx }}>{s.jobName}</div>}
+          {s.newCustomerPhone && <div style={{ fontSize: 10, color: C.txD }}>{s.newCustomerPhone}</div>}
         </div>
       )}
     </Box>

--- a/domains/business/estimator/app/src/hooks/useProjectState.js
+++ b/domains/business/estimator/app/src/hooks/useProjectState.js
@@ -4,7 +4,7 @@ const STORAGE_KEY = 'hwc-estimate-state';
 
 export const DEFAULT_STATE = {
   // Job selection (for JT integration)
-  mode: 'existing',           // 'existing' | 'new_job'
+  mode: 'existing',           // 'existing' | 'new_job' | 'new_customer'
   customerId: '',
   customerName: '',
   locationId: '',
@@ -13,6 +13,15 @@ export const DEFAULT_STATE = {
   jobName: '',
   address: '',
   projectType: 'bathroom',
+
+  // New customer fields (for new_customer mode)
+  newCustomerName: '',
+  newCustomerPhone: '',
+  newCustomerEmail: '',
+  newCustomerStreet: '',
+  newCustomerCity: '',
+  newCustomerState: 'MT',
+  newCustomerZip: '',
 
   // ── Room measurements (JT numeric parameters) ──
   bathroom_length_ft: 10,


### PR DESCRIPTION
## Summary

- Adds a third mode ("New Customer") to the estimator PWA alongside Existing Job and New Job
- Entering customer name, phone, email, address, and job name triggers account → location → job creation in JT via the n8n estimate router before pushing budget line items
- Eliminates the manual step of creating a customer in JobTread first for walk-ins and referrals

## Changes

**React app** (`domains/business/estimator/app/src/`):
- `useProjectState.js` — 7 new `newCustomer*` fields in DEFAULT_STATE
- `JobSelector.jsx` — 3-button mode toggle, inline customer form with name/phone/email/address fields, mode change cleanup, new customer summary card
- `EstimateTab.jsx` — per-mode `canPush()` validation, `newCustomer` object in payload, `accountCreated` in result display

**n8n workflow** (`domains/automation/n8n/parts/workflows/08b-estimate-router.json`):
- `Validate Request` — accepts `new_customer` mode, validates `newCustomer.name`
- `Is New Job?` — condition changed to `notEquals "existing"` (routes both `new_job` and `new_customer`)
- 5 new nodes: `Is New Customer?` → `Create JT Account` → `Create JT Location` → `Create Job (New Customer)` → `Parse New Customer Job`
- `Respond Success` — returns `accountCreated` and `customerId` fields

## Test plan

- [ ] Toggle between all 3 modes — verify fields show/hide and clear correctly
- [ ] In new_customer mode: Push button disabled until both customer name and job name filled
- [ ] Push with new customer data — verify JT creates account, location, and job
- [ ] Verify existing job and new job modes still work unchanged
- [ ] Check Slack notification and Postgres archive include new customer info

https://claude.ai/code/session_01Qba2efrgARTG1iSHRA9AHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qba2efrgARTG1iSHRA9AHp)_