### PR TITLE
Add tasks domain: VTODO/Reminders sync via vdirsyncer + todoman

### DIFF
--- a/domains/mail/README.md
+++ b/domains/mail/README.md
@@ -34,11 +34,16 @@ mail/
 │       ├── runtime.nix        # Env vars, PATH handling
 │       └── service.nix        # systemd user service unit
 ├── calendar/
-│   ├── index.nix              # khal + vdirsyncer integration
+│   ├── index.nix              # khal + vdirsyncer integration; extraVdirsyncerPairs option
 │   └── parts/
 │       ├── khal.nix           # Calendar config
-│       ├── vdirsyncer.nix     # Google Calendar OAuth setup
-│       └── service.nix        # vdirsyncer sync timer
+│       ├── vdirsyncer.nix     # iCloud CalDAV config (+ appends sibling pairs)
+│       └── service.nix        # vdirsyncer sync timer (shared by calendar + tasks)
+├── tasks/
+│   ├── index.nix              # VTODO/Reminders sync + todoman (shares calendar config/timer)
+│   └── parts/
+│       ├── vdirsyncer-pair.nix # [pair tasks] fragment (item_types = ["VTODO"])
+│       └── todoman-config.nix  # ~/.config/todoman/config.py
 ├── mbsync/
 │   ├── index.nix              # mbsync module
 │   └── parts/
@@ -68,6 +73,7 @@ mail/
 Proton Bridge (v3.21.x) occasionally refuses APPEND for messages it considers duplicates of "recovered messages" (error code 2501). This causes mbsync to exit non-zero. As of 2026-04-02, sync-mail tolerates mbsync partial failures so that `notmuch new` always runs — this prevents a cascading bug where un-indexed label copies trigger infinite re-copying by the label copy-back loop. The mbsync exit code is still propagated to systemd for monitoring visibility.
 
 ## Changelog
+- 2026-06-11: Added `tasks/` — VTODO/Reminders sync via vdirsyncer + todoman CLI. Contributes a `[pair tasks]` (item_types=["VTODO"]) to the calendar vdirsyncer config via new `hwc.mail.calendar.extraVdirsyncerPairs`, so there's one config file and one sync timer. Reuses calendar's icloud account + apple-app-pw secret. TUI (`tasq`) deferred to Phase B.
 - 2026-06-09: Removed orphan `protonmail-bridge/` (sys.nix-only clone of `bridge/sys.nix` under a different namespace, imported nowhere; flagged by audit as a latent duplicate `systemd.services.protonmail-bridge` definition). `bridge/` remains the canonical module; `protonmail-bridge-cert/` kept (unique cert-export logic).
 - 2026-04-25: Bridge restart resilience — Restart=always, StartLimitBurst=10/3600s, RestartSec=30 (was on-failure/5s with default 5/10s limit). Health check: stable cooldown fingerprints (strip numbers before hashing), auto-restart bridge on failure, purge stale cooldowns after 7 days. Fixes Apr 2-5 incident (67 spurious critical alerts, 3 days unrecovered downtime)
 - 2026-04-02: Fix sync-mail to tolerate mbsync partial failures — `notmuch new` now always runs even when Bridge rejects messages. Prevents cascading duplicate copy bug in label copy-back (1833 orphan copies accumulated before fix)

--- a/domains/mail/calendar/index.nix
+++ b/domains/mail/calendar/index.nix
@@ -33,6 +33,17 @@ in
       enable = lib.mkEnableOption "auto-import .ics files dropped in ~/000_inbox/downloads into khal";
     };
 
+    extraVdirsyncerPairs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [];
+      description = ''
+        Extra [pair …]/[storage …] blocks contributed by sibling modules
+        (e.g. domains/mail/tasks for VTODO/Reminders sync), appended verbatim
+        to the single generated vdirsyncer config so there is one config file
+        and one sync timer. Each entry is a complete config fragment.
+      '';
+    };
+
     accounts = lib.mkOption {
       type = lib.types.attrsOf (lib.types.submodule {
         options = {

--- a/domains/mail/calendar/parts/vdirsyncer.nix
+++ b/domains/mail/calendar/parts/vdirsyncer.nix
@@ -22,6 +22,10 @@ let
   '';
 
   pairs = lib.concatStringsSep "\n" (lib.mapAttrsToList mkPair cfg.accounts);
+
+  # Pairs contributed by sibling modules (e.g. mail/tasks → VTODO/Reminders).
+  # Kept in the same config so vdirsyncer has one config file + one timer.
+  extraPairs = lib.concatStringsSep "\n" cfg.extraVdirsyncerPairs;
 in
 {
   config = ''
@@ -29,5 +33,6 @@ in
     status_path = "${dataDir}/status/"
 
     ${pairs}
+    ${extraPairs}
   '';
 }

--- a/domains/mail/tasks/README.md
+++ b/domains/mail/tasks/README.md
@@ -1,0 +1,65 @@
+# Mail Tasks (VTODO sync + todoman)
+
+## Purpose
+Sync tasks between the laptop and Apple Reminders on the phone, using iCalendar
+VTODO `.ics` files as the source of truth. vdirsyncer mirrors a local vdir ↔
+iCloud CalDAV (VTODO collections = Reminders), and `todoman` is the reference
+CLI for reading/writing tasks.
+
+## Boundaries
+- Manages: the `tasks` vdirsyncer pair (VTODO), the local tasks vdir, todoman's
+  `config.py`, and the `~/.cache/todoman` / `~/.local/share/vdirsyncer/tasks`
+  directories.
+- Does NOT manage: its own vdirsyncer config file or sync timer. It contributes
+  a `[pair tasks]` fragment to `hwc.mail.calendar.extraVdirsyncerPairs`, so there
+  is exactly one `~/.config/vdirsyncer/config` and one `vdirsyncer.service`/timer
+  (owned by `domains/mail/calendar/`). Requires `hwc.mail.calendar.enable = true`.
+- Does NOT (yet) provide a TUI — see Phase B (`tasq`) in the project plan.
+
+## Structure
+```
+tasks/
+├── index.nix                   # Module: options hwc.mail.tasks.*, todoman pkg,
+│                               #   config.py, dir activation, pair contribution
+└── parts/
+    ├── vdirsyncer-pair.nix     # [pair tasks] fragment (item_types = ["VTODO"])
+    └── todoman-config.nix      # ~/.config/todoman/config.py text
+```
+
+## Secret + account
+Reuses calendar's `apple-app-pw` agenix secret via the same handshake
+(`osConfig.age.secrets.apple-app-pw.path`, falling back to
+`/run/agenix/apple-app-pw` under standalone `hms`). The Apple ID email is taken
+from `hwc.mail.calendar.accounts.<hwc.mail.tasks.account>` (default `icloud`).
+
+## iCloud VTODO go/no-go (run on the laptop after first `hms`)
+1. `hms` runs clean.
+2. `cat ~/.config/vdirsyncer/config` shows both the calendar pairs and
+   `[pair tasks]` with `item_types = ["VTODO"]`; password fetched from the secret
+   path, not a literal.
+3. `systemctl --user list-timers | grep vdirsyncer` → exactly one timer.
+4. `vdirsyncer discover tasks` lists ≥1 VTODO/Reminders collection. Zero ⇒ no-go
+   (fall back to self-hosted Radicale). If empty, try the per-dsid principal URL
+   instead of bare `https://caldav.icloud.com/`.
+5. `vdirsyncer sync tasks`, then
+   `find ~/.local/share/vdirsyncer/tasks -name '*.ics' | xargs grep -l VTODO`.
+6. Round-trip: `todo new -l <list> "vdir test from laptop"` → `vdirsyncer sync
+   tasks` → confirm it appears in Apple Reminders on the phone; add a reminder on
+   the phone → sync → `todo list`.
+7. CATEGORIES check (feeds Phase B `tasq` model mapping): confirm a
+   `+project`/category survives the round-trip into Reminders. Record the result
+   below — it decides whether Phase B encodes project/context via `CATEGORIES` or
+   inline in the summary.
+8. If `default_list` (`hwc.mail.tasks.defaultList`) doesn't match the discovered
+   collection directory name, correct it and re-run `hms`.
+
+**GO** only if discover lists a VTODO collection AND todoman→Reminders AND
+Reminders→local all work.
+
+### Go/no-go result
+- (to be filled in after running on the laptop)
+- CATEGORIES round-trip: _unknown_
+
+## Changelog
+- 2026-06-11: Initial Phase A — vdirsyncer VTODO pair (contributed to the shared
+  calendar config/timer) + todoman CLI and config. TUI (`tasq`) deferred to Phase B.

--- a/domains/mail/tasks/README.md
+++ b/domains/mail/tasks/README.md
@@ -40,7 +40,16 @@ from `hwc.mail.calendar.accounts.<hwc.mail.tasks.account>` (default `icloud`).
 3. `systemctl --user list-timers | grep vdirsyncer` → exactly one timer.
 4. `vdirsyncer discover tasks` lists ≥1 VTODO/Reminders collection. Zero ⇒ no-go
    (fall back to self-hosted Radicale). If empty, try the per-dsid principal URL
-   instead of bare `https://caldav.icloud.com/`.
+   instead of bare `https://caldav.icloud.com/`. **Gotcha:** discovery returns
+   ALL CalDAV collections — VEVENT calendars too — because vdirsyncer has no
+   component filter for discovery (`item_types` only filters items at sync). If
+   two collections share a display name (e.g. a "Family" calendar AND a "Family"
+   reminders list), todoman aborts with *"More than one list has the same
+   identity"*. Pin `hwc.mail.tasks.collections` to the VTODO collection IDs.
+   Identify them with a `supported-calendar-component-set` PROPFIND per collection
+   (look for `<comp name='VTODO'/>`); set the IDs in the machine one-off, then
+   delete any stale VEVENT dirs left under `~/.local/share/vdirsyncer/tasks/` and
+   reset `status/tasks.collections` before re-discovering.
 5. `vdirsyncer sync tasks`, then
    `find ~/.local/share/vdirsyncer/tasks -name '*.ics' | xargs grep -l VTODO`.
 6. Round-trip: `todo new -l <list> "vdir test from laptop"` → `vdirsyncer sync
@@ -56,10 +65,23 @@ from `hwc.mail.calendar.accounts.<hwc.mail.tasks.account>` (default `icloud`).
 **GO** only if discover lists a VTODO collection AND todoman→Reminders AND
 Reminders→local all work.
 
-### Go/no-go result
-- (to be filled in after running on the laptop)
-- CATEGORIES round-trip: _unknown_
+### Go/no-go result (verified on hwc-laptop, 2026-06-11) — **GO**
+- `vdirsyncer discover` exposed 2 VTODO collections: `36BB690C…` ("Reminders")
+  and `D788714B…` ("Family"); the other 4 discovered collections are VEVENT and
+  are excluded via `hwc.mail.tasks.collections`.
+- Sync down pulled a real reminder ("Ryan's bday"); `todo list` reads it.
+- Write: `todo new` → `vdirsyncer sync` uploaded the VTODO to iCloud (visible in
+  Apple Reminders). Delete propagated too.
+- **CATEGORIES round-trip: PRESERVED.** Apple stored `CATEGORIES:work,urgent` and
+  `PRIORITY:1` intact through the round-trip → Phase B (`tasq`) maps
+  `+project/@context` to `Todo.categories` (no inline-summary fallback needed).
 
 ## Changelog
+- 2026-06-11: Phase A verified GO on hwc-laptop. Added `hwc.mail.tasks.collections`
+  to pin the pair to VTODO collections (vdirsyncer over-discovers VEVENT calendars,
+  which broke todoman on a duplicate "Family" name); pinned the laptop to its two
+  Reminders lists in `machines/laptop/home.nix`. Enabled tasks on the laptop there
+  (it wires mail per-machine, not via the mail role). CATEGORIES confirmed to
+  survive iCloud round-trip.
 - 2026-06-11: Initial Phase A — vdirsyncer VTODO pair (contributed to the shared
   calendar config/timer) + todoman CLI and config. TUI (`tasq`) deferred to Phase B.

--- a/domains/mail/tasks/index.nix
+++ b/domains/mail/tasks/index.nix
@@ -1,0 +1,108 @@
+# domains/mail/tasks/index.nix
+#
+# tasks — VTODO/Reminders sync substrate + todoman CLI.
+#
+# NAMESPACE: hwc.mail.tasks.*   (Charter Law 2: namespace = folder)
+# USAGE:     hwc.mail.tasks.enable = true;
+#
+# Auto-imported by domains/mail/index.nix (readDir). Enabled in
+# profiles/mail/home.nix.
+#
+# This module does NOT run its own vdirsyncer config or timer. It contributes a
+# [pair tasks] fragment to hwc.mail.calendar.extraVdirsyncerPairs, so the single
+# calendar vdirsyncer config + 15-min user timer also sync VTODOs. Tasks
+# therefore require hwc.mail.calendar to be enabled (asserted below).
+
+{ config, lib, pkgs, osConfig ? {}, ... }:
+
+let
+  cfg = config.hwc.mail.tasks;
+
+  dataDir = "~/.local/share/vdirsyncer";
+
+  # Handshake: safe access to agenix secrets (mirrors calendar/index.nix).
+  # Use osConfig.age.secrets path when HM evaluates as a NixOS module
+  # (sudo nixos-rebuild). Fall back to the canonical agenix runtime path so
+  # standalone HM (`hms`) doesn't rewrite the config with /dev/null — the secret
+  # file exists at this path regardless of HM eval mode.
+  isNixOSHost = osConfig ? hwc;
+  osCfg = if isNixOSHost then osConfig else {};
+  hasApplePw = (osCfg ? age) && (osCfg.age.secrets ? apple-app-pw);
+  applePwPath = if hasApplePw
+    then osCfg.age.secrets.apple-app-pw.path
+    else "/run/agenix/apple-app-pw";
+
+  # Reuse the calendar account's email — same Apple ID, same secret.
+  calAccounts = config.hwc.mail.calendar.accounts;
+  hasAccount = calAccounts ? ${cfg.account};
+  email = if hasAccount then calAccounts.${cfg.account}.email else "";
+
+  tasksPair = import ./parts/vdirsyncer-pair.nix {
+    inherit email applePwPath dataDir;
+  };
+
+  todomanConfig = import ./parts/todoman-config.nix {
+    defaultList = cfg.defaultList;
+  };
+in
+{
+  #============================================================================
+  # OPTIONS
+  #============================================================================
+  options.hwc.mail.tasks = {
+    enable = lib.mkEnableOption "VTODO/Reminders task sync via vdirsyncer + todoman";
+
+    account = lib.mkOption {
+      type = lib.types.str;
+      default = "icloud";
+      description = ''
+        Name of the hwc.mail.calendar.accounts.<name> entry whose email/Apple ID
+        is reused for the tasks CalDAV pair. The same apple-app-pw secret is used.
+      '';
+    };
+
+    defaultList = lib.mkOption {
+      type = lib.types.str;
+      default = "Reminders";
+      description = ''
+        todoman default_list for `todo new` when -l is omitted. Must match a
+        collection directory created by `vdirsyncer discover tasks`; correct it
+        and re-run `hms` if the discovered list name differs.
+      '';
+    };
+  };
+
+  #============================================================================
+  # IMPLEMENTATION
+  #============================================================================
+  config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.todoman ];
+
+    # Contribute the tasks pair to the shared (calendar) vdirsyncer config.
+    hwc.mail.calendar.extraVdirsyncerPairs = [ tasksPair ];
+
+    # Read-only config.py (todoman does not rewrite it → store symlink is fine).
+    xdg.configFile."todoman/config.py".text = todomanConfig;
+
+    # Ensure the local vdir + cache dirs exist (mirrors calendar's calendarDirs).
+    home.activation.tasksDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      run mkdir -p ~/.local/share/vdirsyncer/tasks ~/.cache/todoman
+    '';
+
+    #==========================================================================
+    # VALIDATION
+    #==========================================================================
+    assertions = [
+      {
+        assertion = config.hwc.mail.calendar.enable;
+        message = "hwc.mail.tasks requires hwc.mail.calendar.enable = true "
+          + "(it shares the calendar vdirsyncer config and sync timer).";
+      }
+      {
+        assertion = hasAccount && email != "";
+        message = "hwc.mail.tasks.account = \"${cfg.account}\" must name an "
+          + "existing hwc.mail.calendar.accounts.<name> entry with an email set.";
+      }
+    ];
+  };
+}

--- a/domains/mail/tasks/index.nix
+++ b/domains/mail/tasks/index.nix
@@ -39,6 +39,7 @@ let
 
   tasksPair = import ./parts/vdirsyncer-pair.nix {
     inherit email applePwPath dataDir;
+    collections = cfg.collections;
   };
 
   todomanConfig = import ./parts/todoman-config.nix {
@@ -68,6 +69,22 @@ in
         todoman default_list for `todo new` when -l is omitted. Must match a
         collection directory created by `vdirsyncer discover tasks`; correct it
         and re-run `hms` if the discovered list name differs.
+      '';
+    };
+
+    collections = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "from a" "from b" ];
+      example = [ "36BB690C-8948-4AB5-A0CB-C0596887C4E5" ];
+      description = ''
+        vdirsyncer `collections` for the tasks pair. Defaults to auto-discovery
+        ("from a"/"from b"), but iCloud advertises VEVENT calendars alongside
+        VTODO reminder lists and vdirsyncer cannot filter discovery by component
+        type — auto-discovery therefore pulls calendars in and breaks todoman on
+        duplicate display names. Pin this to the VTODO collection IDs (the Apple
+        Reminders lists). Find them with `vdirsyncer discover tasks` and a
+        `supported-calendar-component-set` PROPFIND. This is account-specific, so
+        set it in the machine one-off, not here.
       '';
     };
   };

--- a/domains/mail/tasks/parts/todoman-config.nix
+++ b/domains/mail/tasks/parts/todoman-config.nix
@@ -1,0 +1,23 @@
+# domains/mail/tasks/parts/todoman-config.nix
+#
+# Returns the text of ~/.config/todoman/config.py. todoman's config is
+# executable Python with module-level variables (read from todoman 4.7.0).
+# A read-only store symlink is fine — todoman does not rewrite this file.
+
+{ defaultList }:
+
+''
+  # Glob over vdirsyncer's tasks vdir: one subdir per remote Reminders list.
+  path = "~/.local/share/vdirsyncer/tasks/*"
+
+  # Default list for `todo new` when -l is omitted. NOTE: this must match a
+  # collection directory name created by `vdirsyncer discover tasks`. If the
+  # discovered list name differs (e.g. "Reminders" vs a localized name), update
+  # this value and re-run `hms`. See README go/no-go step 8.
+  default_list = "${defaultList}"
+
+  date_format = "%Y-%m-%d"
+  time_format = "%H:%M"
+  default_due = 0
+  cache_path = "~/.cache/todoman/cache.sqlite3"
+''

--- a/domains/mail/tasks/parts/vdirsyncer-pair.nix
+++ b/domains/mail/tasks/parts/vdirsyncer-pair.nix
@@ -4,16 +4,21 @@
 # config. Contributed to hwc.mail.calendar.extraVdirsyncerPairs so there is a
 # single vdirsyncer config file and a single sync timer.
 #
-# The `item_types = ["VTODO"]` line is the knob that makes CalDAV expose Apple
-# Reminders (VTODO) collections instead of calendars (VEVENT).
+# The `item_types = ["VTODO"]` line is the knob that makes CalDAV sync only Apple
+# Reminders (VTODO) items, not calendar (VEVENT) items. Note: it filters ITEMS at
+# sync time, NOT collection discovery — vdirsyncer has no component filter for
+# discovery, so `collections = ["from a","from b"]` would pull every calendar too
+# (and break todoman on duplicate display names). Pin `collections` to the VTODO
+# collection IDs instead (see hwc.mail.tasks.collections; discover them with
+# `vdirsyncer discover tasks` + a supported-calendar-component-set PROPFIND).
 
-{ email, applePwPath, dataDir }:
+{ email, applePwPath, dataDir, collections }:
 
 ''
   [pair tasks]
   a = "tasks_remote"
   b = "tasks_local"
-  collections = ["from a", "from b"]
+  collections = ${builtins.toJSON collections}
   metadata = ["displayname"]
 
   [storage tasks_remote]

--- a/domains/mail/tasks/parts/vdirsyncer-pair.nix
+++ b/domains/mail/tasks/parts/vdirsyncer-pair.nix
@@ -1,0 +1,30 @@
+# domains/mail/tasks/parts/vdirsyncer-pair.nix
+#
+# Returns the [pair tasks] + [storage …] fragment for the shared vdirsyncer
+# config. Contributed to hwc.mail.calendar.extraVdirsyncerPairs so there is a
+# single vdirsyncer config file and a single sync timer.
+#
+# The `item_types = ["VTODO"]` line is the knob that makes CalDAV expose Apple
+# Reminders (VTODO) collections instead of calendars (VEVENT).
+
+{ email, applePwPath, dataDir }:
+
+''
+  [pair tasks]
+  a = "tasks_remote"
+  b = "tasks_local"
+  collections = ["from a", "from b"]
+  metadata = ["displayname"]
+
+  [storage tasks_remote]
+  type = "caldav"
+  url = "https://caldav.icloud.com/"
+  username = "${email}"
+  password.fetch = ["command", "cat", "${applePwPath}"]
+  item_types = ["VTODO"]
+
+  [storage tasks_local]
+  type = "filesystem"
+  path = "${dataDir}/tasks/"
+  fileext = ".ics"
+''

--- a/machines/laptop/home.nix
+++ b/machines/laptop/home.nix
@@ -50,7 +50,17 @@
   # Tasks: Apple Reminders (VTODO) sync via todoman, riding the calendar
   # vdirsyncer config + timer above. The laptop wires mail per-machine (no mail
   # role), so tasks is enabled here rather than in profiles/mail/home.nix.
-  hwc.mail.tasks.enable = true;
+  hwc.mail.tasks = {
+    enable = true;
+    # The two VTODO (Reminders) collections in this iCloud account. The other
+    # discovered collections are VEVENT calendars (Home/Calendar/Work/Family-cal)
+    # and must be excluded or todoman breaks on the duplicate "Family" name.
+    # Verified via supported-calendar-component-set PROPFIND (2026-06-11):
+    collections = [
+      "36BB690C-8948-4AB5-A0CB-C0596887C4E5"  # "Reminders"
+      "D788714B-EA8C-44D1-A16F-ECF1A88ADCC6"  # "Family"
+    ];
+  };
 
   hwc.mail.mbsync.enable = false;
 

--- a/machines/laptop/home.nix
+++ b/machines/laptop/home.nix
@@ -46,6 +46,12 @@
       };
     };
   };
+
+  # Tasks: Apple Reminders (VTODO) sync via todoman, riding the calendar
+  # vdirsyncer config + timer above. The laptop wires mail per-machine (no mail
+  # role), so tasks is enabled here rather than in profiles/mail/home.nix.
+  hwc.mail.tasks.enable = true;
+
   hwc.mail.mbsync.enable = false;
 
   hwc.mail.health = {

--- a/profiles/mail/home.nix
+++ b/profiles/mail/home.nix
@@ -26,6 +26,10 @@
       };
     };
 
+    # VTODO/Reminders sync (todoman). Shares calendar's vdirsyncer config + timer
+    # and reuses the icloud account above.
+    tasks.enable = true;
+
     health = {
       enable = true;
       # webhook.url names a concrete host — it lives in the machine one-off


### PR DESCRIPTION
## Summary
Introduces a new `domains/mail/tasks/` module for syncing Apple Reminders (VTODO) with the laptop via iCalendar files. Tasks leverage the existing calendar vdirsyncer infrastructure to avoid duplication of config files and sync timers.

## Key Changes

- **New `domains/mail/tasks/` module** with three components:
  - `index.nix`: Main module providing `hwc.mail.tasks.*` options (enable, account, defaultList), todoman package installation, config.py generation, and directory activation
  - `parts/vdirsyncer-pair.nix`: Generates `[pair tasks]` + `[storage tasks_*]` config fragment with `item_types = ["VTODO"]` for CalDAV VTODO collections
  - `parts/todoman-config.nix`: Generates todoman's `config.py` with vdirsyncer path glob and default list configuration

- **Integration with calendar domain**:
  - Added `hwc.mail.calendar.extraVdirsyncerPairs` option to allow sibling modules to contribute vdirsyncer config fragments
  - Modified `domains/mail/calendar/parts/vdirsyncer.nix` to append extra pairs to the single shared config file
  - Tasks module contributes its pair via this mechanism, ensuring one vdirsyncer config and one sync timer

- **Account and secret reuse**:
  - Tasks reuse the calendar's iCloud account email and `apple-app-pw` agenix secret
  - Implements safe osConfig handshake (mirrors calendar's pattern) to access secrets in both HM-as-module and HM-as-flake contexts

- **Validation**:
  - Asserts `hwc.mail.calendar.enable = true` (required for shared config/timer)
  - Asserts the configured account exists in calendar accounts with a valid email

- **Documentation**:
  - Added comprehensive `domains/mail/tasks/README.md` with purpose, boundaries, structure, secret handling, and iCloud VTODO go/no-go checklist
  - Updated `domains/mail/README.md` with tasks module structure and changelog entry
  - Enabled tasks in `profiles/mail/home.nix` with inline comment explaining shared infrastructure

## Implementation Details

- Tasks do NOT run their own vdirsyncer config or timer; they contribute a fragment to the calendar's config via `extraVdirsyncerPairs`
- The `item_types = ["VTODO"]` line in the pair is the key knob that makes CalDAV expose Reminders collections instead of calendars
- todoman config is read-only (store symlink), as todoman does not rewrite it
- Directory activation creates `~/.local/share/vdirsyncer/tasks/` and `~/.cache/todoman/` on first `hms` run
- Phase A (this PR) provides CLI-only task management; Phase B will add a TUI (`tasq`)

Follows Charter Law 2 (namespace = folder) and maintains layer purity by keeping tasks as a domain module that contributes to calendar's shared infrastructure.

https://claude.ai/code/session_01F7GWTwnqKVGB664k2k4SPw