### PR TITLE
feat(system/mcp): Universal Result Contract on the 4 tile tools

### DIFF
--- a/domains/system/mcp/README.md
+++ b/domains/system/mcp/README.md
@@ -492,6 +492,13 @@ In-memory `TtlCache` with `getOrCompute(key, ttl, fn)`.
 
 ## Changelog
 
+- **2026-06-15**: Universal Result Contract — `hwc_morning_status`, `hwc_calendar`
+  (list), `hwc_tasks_list`, `hwc_leads` (recent) now attach a `view`
+  (`{kind,title,data,meta}`, new `result.ts` helper + `ResultEnvelope`/`view` in
+  `types.ts`). `backend-manager` dual-emits it as MCP `structuredContent`
+  alongside the unchanged legacy text block, so the workbench TUI tiles (and the
+  future Portal) render with no per-tool adapter; existing prose/LLM readers are
+  unaffected. Producer half of [[universal_result_contract]].
 - **2026-06-11**: Added `hwc_tasks_*` (4 tools) — task CRUD + list management
   over the self-hosted Radicale CalDAV backend (new `executors/caldav.ts`:
   fetch-based PROPFIND/REPORT/PUT/DELETE/MKCALENDAR + VTODO codec with
@@ -547,6 +554,7 @@ domains/system/mcp/
         ├── index.ts
         ├── config.ts
         ├── backend-manager.ts
+        ├── result.ts                    # Universal Result Contract helper (contract(); ResultEnvelope view)
         ├── stdio-backend.ts
         ├── cache.ts
         ├── log.ts

--- a/domains/system/mcp/src/src/backend-manager.ts
+++ b/domains/system/mcp/src/src/backend-manager.ts
@@ -220,7 +220,7 @@ export class BackendManager {
   async callTool(
     name: string,
     args: Record<string, unknown>,
-  ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean; structuredContent?: unknown }> {
     const entry = this.toolMap.get(name);
 
     if (!entry) {
@@ -241,9 +241,14 @@ export class BackendManager {
       try {
         const result = await entry.local.handler(args);
         log.debug("Local tool call completed", { tool: name, status: result.status, durationMs: Date.now() - startMs });
+        // Dual-emit: legacy text block (the full ToolResult, for prose/LLM and
+        // any existing reader) PLUS the Universal Result Contract view as MCP
+        // structuredContent when the tool set one. Contract-aware consumers
+        // (workbench, Portal) prefer structuredContent.
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           isError: result.status === "error",
+          ...(result.view ? { structuredContent: result.view } : {}),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/domains/system/mcp/src/src/result.ts
+++ b/domains/system/mcp/src/src/result.ts
@@ -1,0 +1,31 @@
+/**
+ * Universal Result Contract helpers.
+ *
+ * `contract(kind, title, data, meta)` builds a ResultEnvelope — the
+ * render-ready, self-describing view a tool attaches to its ToolResult.view.
+ * backend-manager emits it as MCP `structuredContent` (dual-emit alongside the
+ * legacy text block). Keep `data` to the kind's canonical fields; push
+ * producer noise (status/message/counts/timing) into `meta`.
+ *
+ * Spec + per-kind field shapes: brain note universal_result_contract_schema.
+ */
+import type { ResultEnvelope, ViewKind } from "./types.js";
+
+export const CONTRACT_VERSION = "1";
+
+export function contract<T>(
+  kind: ViewKind,
+  title: string,
+  data: T,
+  meta: Record<string, unknown> = {},
+): ResultEnvelope<T> {
+  return { kind, title, data, meta: { contract: CONTRACT_VERSION, ...meta } };
+}
+
+/**
+ * Strip a value to a string id; returns "" when absent so callers can decide
+ * whether a row is selectable (the entity rule: truthy id ⇒ selectable).
+ */
+export function asId(value: unknown): string {
+  return value == null ? "" : String(value);
+}

--- a/domains/system/mcp/src/src/tools/calendar.ts
+++ b/domains/system/mcp/src/src/tools/calendar.ts
@@ -7,7 +7,8 @@ import { readdir, readFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { catchError, mcpError } from "../errors.js";
-import type { ToolDef, ToolResult } from "../types.js";
+import { contract } from "../result.js";
+import type { ResultEnvelope, ToolDef, ToolResult } from "../types.js";
 import { log } from "../log.js";
 
 /* ════════════════════════════════════════════════════════════════ */
@@ -71,6 +72,28 @@ interface CalendarEvent {
   summary: string;
   location: string | null;
   allDay: boolean;
+}
+
+/**
+ * Universal Result Contract view (list) for a set of calendar events. id is
+ * synthesized (date+time+summary — khal exposes no stable UID via --format);
+ * label=summary, time=startTime or "all-day"; date/location ride the data bag.
+ */
+function eventsToView(
+  events: CalendarEvent[],
+  title: string,
+  meta: Record<string, unknown>,
+): ResultEnvelope {
+  return contract("list", title, {
+    items: events.map((e) => ({
+      kind: "event",
+      id: `${e.date}|${e.startTime ?? "all-day"}|${e.summary}`,
+      label: e.summary,
+      time: e.allDay ? "all-day" : (e.startTime ?? ""),
+      date: e.date,
+      ...(e.location ? { location: e.location } : {}),
+    })),
+  }, { ...meta, source: "hwc_calendar" });
 }
 
 const DAY_HEADER_RE = /^.+,\s+(\d{4}-\d{2}-\d{2})\s+\w+\s*$/;
@@ -285,6 +308,7 @@ export function calendarTools(): ToolDef[] {
                 status: "ok",
                 message: `${events.length} event${events.length !== 1 ? "s" : ""} on ${dateStr}`,
                 data: { range: "today", date: dateStr, timezone: tz, event_count: events.length, events },
+                view: eventsToView(events, "Today", { range: "today", date: dateStr, timezone: tz, event_count: events.length }),
               };
             }
 
@@ -307,6 +331,7 @@ export function calendarTools(): ToolDef[] {
                 status: "ok",
                 message: `${events.length} event${events.length !== 1 ? "s" : ""} this week`,
                 data: { range: "week", timezone: tz, event_count: events.length, by_date: byDate, events },
+                view: eventsToView(events, "This Week", { range: "week", timezone: tz, event_count: events.length }),
               };
             }
 
@@ -321,6 +346,7 @@ export function calendarTools(): ToolDef[] {
               status: "ok",
               message: `${events.length} event${events.length !== 1 ? "s" : ""} from ${start} to ${end}`,
               data: { range: "custom", start, end, event_count: events.length, events },
+              view: eventsToView(events, `${start} – ${end}`, { range: "custom", start, end, event_count: events.length }),
             };
           } catch (err) {
             return catchError("INTERNAL_ERROR", "Failed to list calendar events", err, "Check that khal is installed and vdirsyncer has synced at least once");

--- a/domains/system/mcp/src/src/tools/leads.ts
+++ b/domains/system/mcp/src/src/tools/leads.ts
@@ -13,6 +13,7 @@
 
 import type { ToolDef, ToolResult } from "../types.js";
 import { mcpError } from "../errors.js";
+import { contract } from "../result.js";
 
 const LEADS_BASE = "http://127.0.0.1:11650";
 
@@ -106,8 +107,45 @@ export function leadsTools(): ToolDef[] {
               if (typeof args.filter_status === "string" && args.filter_status) {
                 params.set("status", args.filter_status);
               }
-              const data = await httpGet(`/leads/recent?${params.toString()}`);
-              return { status: "ok", message: "recent leads", data };
+              const data = await httpGet(`/leads/recent?${params.toString()}`) as {
+                httpStatus?: number;
+                data?: {
+                  count?: number;
+                  rows?: Array<{
+                    id?: string;
+                    status?: string;
+                    payload?: {
+                      source?: string;
+                      contact?: { name?: string };
+                      calc?: { estimate?: { low?: number; high?: number } };
+                    };
+                  }>;
+                };
+              };
+              const leadRows = data?.data?.rows ?? [];
+              const fmtEstimate = (e?: { low?: number; high?: number }): string =>
+                e && typeof e.low === "number" && typeof e.high === "number"
+                  ? `$${Math.round(e.low / 1000)}k–${Math.round(e.high / 1000)}k`
+                  : "";
+              return {
+                status: "ok",
+                message: "recent leads",
+                data,
+                // Universal Result Contract view (table): flatten the lead
+                // service's nested rows into column-keyed cells the renderer
+                // reads via row[col]; id/kind make each row a selectable entity.
+                view: contract("table", "Leads", {
+                  columns: ["Name", "Source", "Estimate", "Status"],
+                  rows: leadRows.map((r) => ({
+                    kind: "lead",
+                    id: r.id ?? "",
+                    Name: r.payload?.contact?.name ?? "",
+                    Source: r.payload?.source ?? "",
+                    Estimate: fmtEstimate(r.payload?.calc?.estimate),
+                    Status: r.status ?? "",
+                  })),
+                }, { count: data?.data?.count ?? leadRows.length, httpStatus: data?.httpStatus, source: "hwc_leads" }),
+              };
             }
             case "get": {
               const leadId = String(args.lead_id ?? "");

--- a/domains/system/mcp/src/src/tools/morning-status.ts
+++ b/domains/system/mcp/src/src/tools/morning-status.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ToolDef, ToolResult } from "../types.js";
+import { contract } from "../result.js";
 import { executeHealthCheck } from "./monitoring.js";
 import { executeMailHealth } from "./mail.js";
 import { khalList } from "./calendar.js";
@@ -126,10 +127,19 @@ export function morningStatusTool(): ToolDef {
 
       const briefing = lines.join("\n");
 
+      // Universal Result Contract view (text): the header line is the greeting,
+      // the per-section lines (Services/Errors/Mail/Storage/Calendar) are the
+      // highlights. lines[0] is the "=== HWC Morning Status — <date> ===" header.
+      const [header, ...sections] = lines;
       return {
         status: "ok",
         message: `Morning status for ${today}`,
         data: { briefing, date: today },
+        view: contract("text", "Morning Briefing", {
+          greeting: header ?? `HWC Morning Status — ${today}`,
+          summary: `${sections.length} section${sections.length !== 1 ? "s" : ""}`,
+          highlights: sections,
+        }, { date: today, source: "hwc_morning_status" }),
       };
     },
   };

--- a/domains/system/mcp/src/src/tools/tasks.ts
+++ b/domains/system/mcp/src/src/tools/tasks.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { catchError, mcpError } from "../errors.js";
+import { contract } from "../result.js";
 import type { ToolDef, ToolResult } from "../types.js";
 import {
   buildVtodo,
@@ -146,10 +147,25 @@ export function tasksTools(): ToolDef[] {
           if (category) out = out.filter((t) => t.categories.includes(category));
           if (grep) out = out.filter((t) => t.summary.toLowerCase().includes(grep));
 
+          const rows = sortTasks(out).map(taskRow);
+          const listNames = lists.map((l) => l.name);
           return {
             status: "ok",
             message: `${out.length} task(s) across ${lists.length} list(s)`,
-            data: { tasks: sortTasks(out).map(taskRow), lists: lists.map((l) => l.name) },
+            data: { tasks: rows, lists: listNames },
+            // Universal Result Contract view (list): id=uid, label=summary; the
+            // rest rides along as the entity data bag (renderer reads time||due).
+            view: contract("list", "Tasks", {
+              items: rows.map((r) => ({
+                kind: "task",
+                id: r.uid,
+                label: r.summary,
+                ...(r.due ? { due: r.due } : {}),
+                list: r.list,
+                status: r.status,
+                ...(r.priority ? { priority: r.priority } : {}),
+              })),
+            }, { count: out.length, lists: listNames, source: "hwc_tasks_list" }),
           };
         } catch (err) {
           return catchError("NETWORK_ERROR", "Failed to list tasks", err,

--- a/domains/system/mcp/src/src/types.ts
+++ b/domains/system/mcp/src/src/types.ts
@@ -13,6 +13,23 @@ export type McpErrorType =
   | "UNAVAILABLE"      // service or endpoint not running
   | "INTERNAL_ERROR";  // unexpected exception
 
+/**
+ * Universal Result Contract — a self-describing, render-ready view of a tool's
+ * payload. Emitted as MCP `structuredContent` (in addition to the legacy text
+ * block) so any consumer — the workbench TUI tiles, the web Portal — renders it
+ * with zero per-tool adapter. `kind` picks the renderer; `data` carries that
+ * kind's canonical fields; producer noise (status/message/etc.) lives in `meta`.
+ * Spec: brain note universal_result_contract_schema.
+ */
+export type ViewKind = "text" | "list" | "table" | "kanban" | "metric" | "status";
+
+export interface ResultEnvelope<T = unknown> {
+  kind: ViewKind;
+  title?: string;
+  data: T;
+  meta?: Record<string, unknown>;
+}
+
 /** Standard result wrapper for all tool responses */
 export interface ToolResult<T = unknown> {
   status: "ok" | "error" | "partial";
@@ -23,6 +40,13 @@ export interface ToolResult<T = unknown> {
   error_type?: McpErrorType;
   suggestion?: string;
   context?: Record<string, unknown>;
+  /**
+   * Optional Universal Result Contract view. When present, backend-manager
+   * emits it as `structuredContent` alongside the legacy text block — the
+   * dual-emit path (legacy readers unaffected; contract-aware consumers prefer
+   * structuredContent). Tools that feed a dashboard tile set this.
+   */
+  view?: ResultEnvelope;
 }
 
 /** Tool definition matching the jt-mcp pattern */


### PR DESCRIPTION
Lands the **producer half** of the Universal Result Contract on `main` — self-contained server infra (no flake/home coupling), so it's safe to merge independently of the larger `feat/workbench-zellij` branch.

## What
`hwc_morning_status` (text), `hwc_calendar`/list (list), `hwc_tasks_list` (list), `hwc_leads`/recent (table) now attach a `view` = `{kind,title,data,meta}` (new `result.ts` `contract()` helper; `ResultEnvelope` + `ToolResult.view` in `types.ts`). `backend-manager` **dual-emits** it as MCP `structuredContent` alongside the **unchanged** legacy text block — structured consumers (the workbench TUI tiles, the future Portal) render with zero per-tool adapter; prose/LLM readers see the same text as before.

## Why
The workbench dashboard tiles read canonical render fields (`items`/`columns`/`rows`/`greeting`) but the tools nested everything under `{status,message,data}`, so the tiles rendered blank. This is the naming-convention fix (one self-describing shape) instead of per-tool adapters. Spec: brain `universal_result_contract` / `_schema` / `_producer_scope`.

## Verified live on hwc-server
All 4 tools emit `structuredContent` with the right `kind` + real data (4 tasks, 10 leads, briefing, calendar). Regression sanity clean (`hwc_services`, `hwc_monitoring`, gateway path unchanged). The laptop workbench consumer (on `feat/workbench-zellij`) was confirmed to unwrap it end-to-end.

## Deploy note
The MCP service runs `${repo}/domains/system/mcp/src/dist/index.js` from the **live checkout** (`dist/` gitignored, no Nix build step). After merge, on hwc-server: `git checkout main && git pull && (cd domains/system/mcp/src && npm install && npm run build) && sudo systemctl restart hwc-sys-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)