### PR TITLE
fix(home/keymap): zellij meta layer uses GoToTab <index> (was GoToTabName → broke config parse)

### DIFF
--- a/domains/home/core/shell/parts/zsh-init.nix
+++ b/domains/home/core/shell/parts/zsh-init.nix
@@ -14,6 +14,23 @@
         _hwc_hash_refresh() { hash -r; }
         add-zsh-hook precmd _hwc_hash_refresh
 
+        # Rebind the running shell's prompt to a live starship binary.
+        # `starship init zsh` bakes the ABSOLUTE path of the binary that ran it
+        # into the prompt hook functions (e.g. __starship_get_time, PROMPT2). A
+        # shell that baked ~/.nix-profile/bin/starship dies on every prompt after
+        # an HM-as-module activation, because activation WIPES ~/.nix-profile —
+        # and `hash -r` can't fix it (it only re-resolves bare command names, not
+        # an absolute path literal inside a function). Re-running init after a
+        # rebuild rebakes the path via PATH, which now lands on the stable
+        # /etc/profiles/per-user/$USER/bin/starship symlink (repopulated every
+        # activation, never wiped). Guarded so hosts with starship disabled skip it.
+        _hwc_reinit_prompt() {
+          hash -r
+          if command -v starship >/dev/null 2>&1; then
+            eval "$(starship init zsh)"
+          fi
+        }
+
         # NixOS rebuild shortcuts (dynamic hostname)
         # `env HOME=/root` stops Nix warning that /home/eric isn't owned by root.
         # Must be the ABSOLUTE path, not `~root`: zsh doesn't tilde-expand it in
@@ -54,14 +71,14 @@
             print
           fi
           _hwc_rebuild switch "$@" || return $?
-          hash -r
+          _hwc_reinit_prompt
           if [ -n "''${HYPRLAND_INSTANCE_SIGNATURE:-}" ]; then
             hyprctl reload >/dev/null
           fi
         }
         tnix() {
           _hwc_rebuild test "$@" || return $?
-          hash -r
+          _hwc_reinit_prompt
           if [ -n "''${HYPRLAND_INSTANCE_SIGNATURE:-}" ]; then
             hyprctl reload >/dev/null
           fi
@@ -82,7 +99,7 @@
             "$HWC_NIXOS_DIR#homeConfigurations.\"eric@$(hostname)\".activationPackage" \
             "$@") || return $?
           "$activator/activate" || return $?
-          hash -r
+          _hwc_reinit_prompt
           if [ -n "''${HYPRLAND_INSTANCE_SIGNATURE:-}" ]; then
             hyprctl reload >/dev/null
           fi

--- a/domains/home/keymap/parts/to-zellij.nix
+++ b/domains/home/keymap/parts/to-zellij.nix
@@ -16,10 +16,13 @@
 { lib, grammar }:
 
 let
-  # target pane/app -> zellij tab name (todui+khalt+host share the dashboard tab)
+  # target pane/app -> zellij tab INDEX (1-based). zellij 0.44 keybinds only
+  # support GoToTab <index>, NOT GoToTabName. Indices MUST match the tab order in
+  # domains/home/apps/zellij/parts/layout.nix:
+  #   1 home (host) · 2 tasks (todui) · 3 cal (khalt) · 4 files · 5 mail · 6 edit
   tabFor = {
-    todui = "workbench"; khalt = "workbench"; workbench = "workbench";
-    mail = "mail"; files = "files"; edit = "edit";
+    workbench = 1; todui = 2; khalt = 3;
+    files = 4; mail = 5; edit = 6;
   };
 
   # nav intent -> zellij action (jumps use GoToTabName, handled separately)
@@ -42,7 +45,7 @@ let
   bindLine = e:
     let tok = keyToken e.key; in
     if (e ? target) then
-      ''        bind "${tok}" { GoToTabName "${tabFor.${e.target}}"; SwitchToMode "Normal"; }''
+      ''        bind "${tok}" { GoToTab ${toString tabFor.${e.target}}; SwitchToMode "Normal"; }''
     # pane-picker LEAVES you in Pane mode to pick — do NOT append a return to Normal.
     else if e.intent == "pane-picker" then
       ''        bind "${tok}" { ${navAction.${e.intent}} }''


### PR DESCRIPTION
**Hotfix for a config-breaking bug.** The keymap factory's zellij generator emitted `GoToTabName "<name>"` for the Alt+Space jump bindings, but zellij 0.44's keybind parser doesn't support that action — so the entire `config.kdl` fails to parse and **zellij won't start** (`wb-reload` errors out). A nix build can't catch this (it only writes the config; zellij parses at launch). Target names were also stale (`"workbench"`/`"mail"`) from before the home-page tab layout landed.

Fix: map targets to 1-based tab **indices** matching `domains/home/apps/zellij/parts/layout.nix` (1 home · 2 tasks · 3 cal · 4 files · 5 mail · 6 edit) and emit `GoToTab <index>`.

Verified: `zellij setup --check` → "Config file: Well defined"; bindings resolve (t→tasks, c→cal, m→mail, f→files, e→edit, h→home). Live on the laptop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)