### PR TITLE
feat(home/workbench): default to HWC hub not DataX

### DIFF
--- a/domains/home/apps/workbench/index.nix
+++ b/domains/home/apps/workbench/index.nix
@@ -82,6 +82,8 @@ in
       gatewayUrl = cfg.gatewayUrl;
       offline = cfg.offline;
       hubsDir = cfg.hubsDir;
+      defaultHub = "hwc";   # land on the HWC (woodcraft) hub, not DataX (alpha-first)
+
       # Peer launch overrides (late binding). Mail runs wherever the shell alias
       # says — on the laptop that's the server over ssh, so DON'T bake a local
       # aerc onto PATH; the launcher invokes `ssh -t server aerc` instead.


### PR DESCRIPTION
Set `defaultHub = "hwc"` so the workbench host opens on the live HWC hub instead of DataX (fixtures, alpha-first). 🤖 Generated with [Claude Code](https://claude.com/claude-code)