### PR TITLE
fix(home): reliable meta leader (Ctrl+b) + host navigates to standing tabs

### DIFF
--- a/domains/home/apps/workbench/index.nix
+++ b/domains/home/apps/workbench/index.nix
@@ -28,6 +28,12 @@ let
   # it falls back to a bare "aerc". Same fact the zellij layout derives.
   aercCmd = (config.hwc.home.core.shell.aliases or {}).aerc or "aerc";
 
+  # Standing-tab map (navigate-to-tab, not spawn-duplicate). Imported from the
+  # SAME source the zellij layout emits its tab names from, so the host can never
+  # navigate to a tab name the layout doesn't actually use. `host` is dropped —
+  # it isn't a launch target (it IS the host).
+  layoutTabs = removeAttrs (import ../zellij/parts/tabs.nix) [ "host" ];
+
   # Unified keymap grammar → staged as ~/.config/workbench/keymap.json. The host
   # has a real chord state machine but its grammar is still hard-coded; the
   # app-side reader (feed Keymap.from_actions globals + DROP the Space t/c/m
@@ -83,6 +89,7 @@ in
       offline = cfg.offline;
       hubsDir = cfg.hubsDir;
       defaultHub = "hwc";   # land on the HWC (woodcraft) hub, not DataX (alpha-first)
+      tabs = layoutTabs;    # plain jumps navigate to the tool's standing tab
 
       # Peer launch overrides (late binding). Mail runs wherever the shell alias
       # says — on the laptop that's the server over ssh, so DON'T bake a local

--- a/domains/home/apps/zellij/parts/layout.nix
+++ b/domains/home/apps/zellij/parts/layout.nix
@@ -15,6 +15,10 @@
 { lib, mailCommand ? "aerc" }:
 
 let
+  # Tab names come from the shared source of truth so the host's WORKBENCH_TABS
+  # (navigate-to-standing-tab) can never drift from the layout's actual names.
+  tabs = import ./tabs.nix;
+
   mailParts = lib.splitString " " mailCommand;
   mailBin   = builtins.head mailParts;
   mailArgs  = builtins.tail mailParts;
@@ -42,29 +46,29 @@ in
             pane size=1 borderless=true { plugin location="zellij:status-bar"; }
         }
         // Home = the workbench host alone (full pane). The dashboard you land on.
-        tab name="🏠 home" focus=true {
+        tab name="${tabs.host}" focus=true {
             pane name="host" {
                 command "workbench"
             }
         }
         // Tasks + calendar: Eric's first-class TUIs, auto-started (always-on peers).
-        tab name="✅ tasks" {
+        tab name="${tabs.todui}" {
             pane name="todui" { command "todui"; }
         }
-        tab name="📆 cal" {
+        tab name="${tabs.khalt}" {
             pane name="khalt" { command "khalt"; }
         }
         // Local TUIs — auto-start, cheap to keep warm.
-        tab name="📁 files" {
+        tab name="${tabs.yazi}" {
             pane name="yazi" { command "yazi"; }
         }
         // Mail is the one heavy peer: `ssh -t server aerc`, a held-open connection
         // to the server — stays start_suspended (press <ENTER> to launch) so no
         // idle SSH lingers in a detached session.
-        tab name="📬 mail" {
+        tab name="${tabs.aerc}" {
             pane name="aerc" { command "${mailBin}";${mailArgsKdl} start_suspended true; }
         }
-        tab name="📝 edit" {
+        tab name="${tabs.nvim}" {
             pane name="nvim" { command "nvim"; }
         }
     }

--- a/domains/home/apps/zellij/parts/tabs.nix
+++ b/domains/home/apps/zellij/parts/tabs.nix
@@ -1,0 +1,21 @@
+# domains/home/apps/zellij/parts/tabs.nix
+#
+# Single source of truth for the workbench tab layout: launch-target -> tab name.
+# Consumed by:
+#   * parts/layout.nix            — emits the workbench KDL (the `tab name=…`s)
+#   * ../../workbench/index.nix   — WORKBENCH_TABS, so the host NAVIGATES to a
+#                                   tool's standing tab instead of spawning a
+#                                   duplicate pane (the spawn-in-home bug).
+#
+# The DECLARATION ORDER here is the zellij tab order, and MUST stay aligned with
+# the GoToTab <index> map in ../../keymap/parts/to-zellij.nix (1-based):
+#   1 host · 2 todui · 3 khalt · 4 yazi · 5 aerc · 6 nvim
+# Rename a tab in ONE place and both the layout and the host follow on rebuild.
+{
+  host  = "🏠 home";
+  todui = "✅ tasks";
+  khalt = "📆 cal";
+  yazi  = "📁 files";
+  aerc  = "📬 mail";
+  nvim  = "📝 edit";
+}

--- a/domains/home/keymap/README.md
+++ b/domains/home/keymap/README.md
@@ -81,12 +81,24 @@ the var is present-but-unread, so drift can't hide — spec premortem #6):
 
 ## Verify before trusting (real-world checks, not eval)
 
-- `Alt+Space` survives Hyprland→kitty→zellij (Super+Space=wofi is a different mod).
+- `Ctrl+b` enters the meta (tmux) mode reliably in kitty→zellij. (We tried
+  `Alt+Space` first; kitty did NOT deliver it to zellij — it leaked through to
+  the focused pane, whose Space-leader then mis-fired. Ctrl-chords are encoded
+  reliably; that's why the meta leader is a Ctrl-chord, like tmux/screen.)
+- `zellij setup --check` reports "Config file: Well defined" — the meta block,
+  GoToTab jumps, and scroll mode all parse (a runtime check `nix build` can't do).
 - kitty keyboard protocol on, so `Ctrl+j` ≠ Enter (two-column nav, spec §3.1b).
 - todui/khalt/workbench log a missing/unread `*_KEYMAP` rather than failing silent.
 
 ## Changelog
 
+- 2026-06-16 — Meta layer hardened (runtime fixes the eval missed). metaLeader
+  `Alt Space`→`Ctrl b` (kitty didn't deliver Alt+Space to zellij → it leaked to
+  the host's Space-leader and mis-spawned). Jumps now emit `GoToTab <index>`
+  (zellij rejects `GoToTabName` in keybinds). Added scrollback (`Ctrl+b s`, with
+  a `scroll` mode block) + detach (`Ctrl+b d`) — clear-defaults had stripped
+  zellij's own, leaving a long-lived session unable to scroll or detach. n/p
+  repurposed to tab-nav (every tool tab is single-pane).
 - 2026-06-15 — Module created + wired. grammar.nix (source of truth) + index.nix
   (theme-mirrored options) + 7 generators + this README. WIRED & git-staged on
   `feat/workbench-zellij`: profile import, zellij meta layer, khalt list-verbs,

--- a/domains/home/keymap/grammar.nix
+++ b/domains/home/keymap/grammar.nix
@@ -32,12 +32,19 @@
 rec {
   #--------------------------------------------------------------------------
   # The two prefixes. Change `metaLeader` here and zellij re-binds (the only
-  # place a global modifier chord is intercepted). Audited free of Hyprland
-  # (Hyprland is all SUPER; only Super+Space=wofi exists) and of every TUI
-  # (only nvim-cmp uses Ctrl+Space, which is why we use ALT+Space).
+  # place a global modifier chord is intercepted).
+  #   * `leader` (Space) is the INTRA-app prefix (handled inside each app).
+  #   * `metaLeader` is the INTER-app prefix, intercepted by zellij.
+  # metaLeader is `Ctrl b` (tmux's own prefix — the meta mode IS zellij's
+  # repurposed `tmux` mode). Ctrl-chords are encoded reliably by every terminal;
+  # `Alt Space` was NOT reliably delivered by kitty (it leaked through to the
+  # focused pane, whose Space-leader then mis-fired — the spawn-in-home bug).
+  # Ctrl+b is clear of Hyprland (all SUPER) and rarely used in the TUIs
+  # (nvim Ctrl+b = page-up, seldom vs Ctrl+u/f); swap the letter here if it ever
+  # collides with an app you care about.
   #--------------------------------------------------------------------------
   leader     = " ";          # Space
-  metaLeader = "Alt Space";   # zellij switches to `meta` mode on this chord
+  metaLeader = "Ctrl b";     # zellij switches to `meta` (tmux) mode on this chord
 
   #--------------------------------------------------------------------------
   # Group letters. The MEANING is the cross-app promise. An app omits groups it
@@ -165,9 +172,10 @@ rec {
   };
 
   #--------------------------------------------------------------------------
-  # The meta layer (Alt+Space -> zellij `meta` mode -> one key). `target` is the
-  # zellij pane/tab name to focus. Jump letters (t/c/m/f/e/h) are disjoint from
-  # the nav letters (n/p/]/[/w/z/Q) — no internal collision.
+  # The meta layer (Ctrl+b -> zellij `meta` mode -> one key). `target` is the
+  # logical pane/tab to focus (mapped to the layout's tab in to-zellij.nix).
+  # Jump letters (t/c/m/f/e/h) are disjoint from the nav/utility letters
+  # (n/p/]/[/w/z/s/d/Q) — no internal collision.
   #--------------------------------------------------------------------------
   meta = [
     { key = "t"; intent = "tasks";    desc = "Tasks (todui)";  target = "todui"; }
@@ -176,13 +184,18 @@ rec {
     { key = "f"; intent = "files";    desc = "Files (yazi)";   target = "files"; }
     { key = "e"; intent = "edit";     desc = "Edit (nvim)";    target = "edit"; }
     { key = "h"; intent = "host";     desc = "Host (workbench)"; target = "workbench"; }
-    # pane/tab navigation (zellij actions, no pane target)
-    { key = "n"; intent = "next-pane"; desc = "Next pane"; }
-    { key = "p"; intent = "prev-pane"; desc = "Prev pane"; }
+    # tab navigation (n/p AND ]/[ — every tool tab is single-pane, so next/prev
+    # *tab* is what you actually want; pane focus lives behind the pane-picker).
+    { key = "n"; intent = "next-tab"; desc = "Next tab"; }
+    { key = "p"; intent = "prev-tab"; desc = "Prev tab"; }
     { key = "bracketright"; intent = "next-tab"; desc = "Next tab"; }
     { key = "bracketleft";  intent = "prev-tab"; desc = "Prev tab"; }
     { key = "w"; intent = "pane-picker"; desc = "Pane picker"; }
     { key = "z"; intent = "zoom";        desc = "Zoom pane"; }
+    # Session lifecycle / scrollback — without these (clear-defaults strips
+    # zellij's own) a long-lived ops session can't scroll output or detach.
+    { key = "s"; intent = "scroll";      desc = "Scrollback"; }
+    { key = "d"; intent = "detach";      desc = "Detach (keep running)"; }
     { key = "Q"; intent = "kill";        desc = "Kill session"; }
   ];
 }

--- a/domains/home/keymap/parts/to-zellij.nix
+++ b/domains/home/keymap/parts/to-zellij.nix
@@ -25,16 +25,21 @@ let
     files = 4; mail = 5; edit = 6;
   };
 
-  # nav intent -> zellij action (jumps use GoToTabName, handled separately)
+  # nav intent -> zellij action (tab jumps use GoToTab <index>, handled separately)
   navAction = {
     next-pane = ''FocusNextPane;'';
     prev-pane = ''FocusPreviousPane;'';
     next-tab  = ''GoToNextTab;'';
     prev-tab  = ''GoToPreviousTab;'';
-    pane-picker = ''SwitchToMode "Pane";'';   # leaves you in pane mode to pick
+    pane-picker = ''SwitchToMode "Pane";'';     # leaves you in pane mode to pick
+    scroll = ''SwitchToMode "Scroll";'';        # leaves you in scroll mode to read
     zoom = ''ToggleFocusFullscreen;'';
+    detach = ''Detach;'';
     kill = ''Quit;'';
   };
+
+  # intents that ENTER another mode — must NOT append a return to Normal.
+  modeSwitchIntents = [ "pane-picker" "scroll" ];
 
   # zellij key tokens for the few non-letter keys in the meta map
   keyToken = k:
@@ -46,8 +51,8 @@ let
     let tok = keyToken e.key; in
     if (e ? target) then
       ''        bind "${tok}" { GoToTab ${toString tabFor.${e.target}}; SwitchToMode "Normal"; }''
-    # pane-picker LEAVES you in Pane mode to pick — do NOT append a return to Normal.
-    else if e.intent == "pane-picker" then
+    # mode-switch intents LEAVE you in the target mode — do NOT return to Normal.
+    else if lib.elem e.intent modeSwitchIntents then
       ''        bind "${tok}" { ${navAction.${e.intent}} }''
     else
       ''        bind "${tok}" { ${navAction.${e.intent}} SwitchToMode "Normal"; }'';
@@ -78,6 +83,19 @@ let
             bind "Up" { MoveFocus "Up"; }
             bind "Down" { MoveFocus "Down"; }
             bind "Enter" { SwitchToMode "Normal"; }
+        }
+        // Scrollback reader (Ctrl+b s). clear-defaults strips zellij's own scroll
+        // mode, so re-supply the essentials here — without it you cannot read
+        // output that scrolled past. Esc/leader returns to Normal.
+        scroll {
+            bind "Esc" "${grammar.metaLeader}" { SwitchToMode "Normal"; }
+            bind "j" "Down" { ScrollDown; }
+            bind "k" "Up" { ScrollUp; }
+            bind "d" { HalfPageScrollDown; }
+            bind "u" { HalfPageScrollUp; }
+            bind "PageDown" { PageScrollDown; }
+            bind "PageUp" { PageScrollUp; }
+            bind "G" { ScrollToBottom; }
         }
     }
   '';

--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781549095,
-        "narHash": "sha256-I5mn+Wc+nN0OHzRxz0pjXxh73AOUiewrzjDCFzvyHdQ=",
+        "lastModified": 1781583314,
+        "narHash": "sha256-aV6D4WNBxVyE6n1UMxG7DivPnbl/D5g32h34GwiDl18=",
         "ref": "refs/heads/main",
-        "rev": "db79d79663d05b2310754140d76933c960639b45",
-        "revCount": 5,
+        "rev": "b6526851611514af93b2fe6083262695be11f223",
+        "revCount": 6,
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
       },


### PR DESCRIPTION
Fixes the two workbench daily-driver bugs from this session, plus the clear-defaults fallout the audit found.

**Bug A — keyboard tab-nav broken.** `Alt Space` wasn't delivered to zellij by kitty; it leaked to the focused pane whose Space-leader fired the hub's `t` (launch todui) → pane spawned into home. Switched the meta leader to **`Ctrl b`** (reliable Ctrl-chord = tmux's prefix; the meta mode is zellij's repurposed tmux mode). Restored **scrollback** (`Ctrl+b s`) and **detach** (`Ctrl+b d`) that `clear-defaults=true` had stripped — a long-lived ops session otherwise can't scroll output or detach (only `Q`, which kills it). `n`/`p` repurposed to tab-nav.

**Bug B — host spawned duplicate panes.** Hub-action jumps (t→todui, c→khalt…) went through `new-pane`, dropping a second copy into the current tab. Now a plain jump **navigates** to the tool's standing tab (`go-to-tab-name`); only entity-seeded opens spawn. Tab names live in one shared source (`zellij/parts/tabs.nix`) consumed by both the layout KDL and the workbench module (`WORKBENCH_TABS`), so they can't drift.

Verified live: `zellij setup --check` clean; `Ctrl b` meta binds present; `WORKBENCH_TABS` baked into the wrapper; app tests 141 passed +3 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)