### PR TITLE
fix(workbench): mop up audit trip-ups (honest fixtures, khalt keybinds)

### DIFF
--- a/domains/home/keymap/README.md
+++ b/domains/home/keymap/README.md
@@ -98,7 +98,10 @@ the var is present-but-unread, so drift can't hide — spec premortem #6):
   (zellij rejects `GoToTabName` in keybinds). Added scrollback (`Ctrl+b s`, with
   a `scroll` mode block) + detach (`Ctrl+b d`) — clear-defaults had stripped
   zellij's own, leaving a long-lived session unable to scroll or detach. n/p
-  repurposed to tab-nav (every tool tab is single-pane).
+  repurposed to tab-nav (every tool tab is single-pane). khalt keybindings made
+  honest: bind add/delete/open→new/delete/view; DROP the false `e`=edit (khal has
+  no safe single-key edit — it edits via `view`/Enter — so khalt omits that verb
+  per the per-app omission rule; `e` stays khal's native export).
 - 2026-06-15 — Module created + wired. grammar.nix (source of truth) + index.nix
   (theme-mirrored options) + 7 generators + this README. WIRED & git-staged on
   `feat/workbench-zellij`: profile import, zellij meta layer, khalt list-verbs,

--- a/domains/home/keymap/parts/to-khalt.nix
+++ b/domains/home/keymap/parts/to-khalt.nix
@@ -20,13 +20,18 @@ let
   keyOf = name: let v = verb name; in if v == null then "" else v.key;
 
   # khal's [keybindings] uses comma-lists of keys per command. We map the shared
-  # verbs onto khal's command names; export/duplicate move under the leader menu.
+  # verbs onto khal's command names. NOTE: khal has no safe single-key "edit" —
+  # editing happens through `view` (Enter shows details, Enter again edits the
+  # event). So khalt binds add/delete/open and OMITS the unified `e`=edit
+  # (per-app omission rule, grammar.nix §DESIGN); `e` stays khal's native export
+  # and `external_edit` (raw .ics in $EDITOR) keeps its `meta E` default — we do
+  # NOT put raw-ics edit on a bare key (khal warns that path skips validation).
   keybindingsBlock = ''
     [keybindings]
     # generated from domains/home/keymap/grammar.nix (list-app verbs)
     new = ${keyOf "add"}
     delete = ${keyOf "delete"}
-    # edit/open keep Enter; khalt also accepts ${keyOf "edit"} for edit via the leader
+    view = ${keyOf "open"}
     leader = ' '
   '';
 

--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781583314,
-        "narHash": "sha256-aV6D4WNBxVyE6n1UMxG7DivPnbl/D5g32h34GwiDl18=",
+        "lastModified": 1781615157,
+        "narHash": "sha256-zRZQb0BBjP3bH+F610H1GiI6M2Yu7n8IAKvH/7DWMgo=",
         "ref": "refs/heads/main",
-        "rev": "b6526851611514af93b2fe6083262695be11f223",
-        "revCount": 6,
+        "rev": "467e0bbd4aef99e47d604425133ea826f73c484a",
+        "revCount": 7,
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
       },


### PR DESCRIPTION
Mops up the open audit findings — honesty fixes, no new features.

- **#2 (looks-live-is-fake):** tiles now show a **`⚠ fixtures`** marker when data is a live-miss fixture fallback (gateway up but the source tool errored/unknown — e.g. the DataX hub's placeholder tools — or the gateway is unreachable). Suppressed in forced-offline mode (the status bar owns that). `McpClient.forced_offline` added to tell the two apart.
- **#3 (khalt e≠edit):** the generator dropped the false `e`=edit claim. khal has no safe single-key edit (it edits via `view`/Enter), so khalt binds add/delete/open→new/delete/view and omits the unified `e` (per-app omission rule); `e` stays khal's native export.
- **#4 (bare keys):** documented the host's input-free invariant (bare `q`/`r`/`[`/`]` are only safe while no tile takes text).

Verified: app tests 142 passed (+1); khalt config emits `new=a`/`delete=d`/`view=enter`; HM builds & activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)