### PR TITLE
feat(mcp): Result Contract for 6 server tools + workbench Server hub

### DIFF
--- a/domains/system/mcp/README.md
+++ b/domains/system/mcp/README.md
@@ -492,6 +492,13 @@ In-memory `TtlCache` with `getOrCompute(key, ttl, fn)`.
 
 ## Changelog
 
+- **2026-06-16**: Universal Result Contract extended to the **server-health
+  tools** — `hwc_services`, `hwc_storage_status`, `hwc_monitoring`,
+  `hwc_media_status`, `hwc_network`, `hwc_build_git_status` now attach a
+  `view: contract("status", …)` (per-mount/per-service/per-check `{status,name,note}`
+  with green/yellow/red `overall`; producer noise stays in `meta`). Purely
+  additive — legacy `{status,message,data}` untouched. Powers the workbench
+  **Server hub**. Deploy: `npm run build` in `src/` + restart the gateway.
 - **2026-06-15**: `hwc_calendar` switched off plain khal onto **khalt** (the
   forked khal/ikhal; `inputs.khalt` package ships the full `khal` CLI). The
   service now exports `HWC_KHAL_BIN` (khalt's `khal`) and `HWC_KHALT_CONFIG`

--- a/domains/system/mcp/src/src/tools/build.ts
+++ b/domains/system/mcp/src/src/tools/build.ts
@@ -6,6 +6,7 @@ import type { ToolDef, ToolResult } from "../types.js";
 import { catchError } from "../errors.js";
 import { safeExec } from "../executors/shell.js";
 import { TtlCache } from "../cache.js";
+import { contract } from "../result.js";
 
 const cache = new TtlCache();
 
@@ -74,6 +75,28 @@ export function buildTools(nixosConfigPath: string, runtimeTtl: number): ToolDef
               unpushedCount,
               recentCommits,
             },
+            view: contract(
+              "status",
+              "NixOS Git",
+              {
+                overall:
+                  uncommitted.length > 0 || unpushedCount > 0 ? "warning" : "ok",
+                checks: [
+                  { status: "ok", name: "branch", note: branch },
+                  {
+                    status: uncommitted.length ? "warning" : "ok",
+                    name: "uncommitted",
+                    note: `${uncommitted.length} files`,
+                  },
+                  {
+                    status: unpushedCount ? "warning" : "ok",
+                    name: "unpushed",
+                    note: `${unpushedCount} commits`,
+                  },
+                ],
+              },
+              { source: "hwc_build_git_status" },
+            ),
           };
         } catch (err) {
           return catchError("INTERNAL_ERROR", "Failed to query git status", err, "Is the nixos-hwc repo accessible?");

--- a/domains/system/mcp/src/src/tools/media.ts
+++ b/domains/system/mcp/src/src/tools/media.ts
@@ -5,6 +5,7 @@
 import { readFile } from "node:fs/promises";
 import type { ToolDef, ToolResult } from "../types.js";
 import { catchError } from "../errors.js";
+import { contract } from "../result.js";
 
 const ARR_SERVICES = [
   { name: "sonarr", port: 8989 },
@@ -190,10 +191,28 @@ export function mediaTools(): ToolDef[] {
             parts.push("downloads checked");
           }
 
+          // Universal Result Contract view — one check per arr service.
+          const arrServices = ((data.arr as Record<string, unknown> | undefined)?.services as Array<Record<string, unknown>> | undefined) ?? [];
+          const checks = arrServices.map((svc) => {
+            const running = svc.running === true;
+            const warnCount = (svc.healthWarningCount as number) ?? 0;
+            const noteParts: string[] = [];
+            if (svc.port != null) noteParts.push(`:${svc.port}`);
+            if (warnCount > 0) noteParts.push(`${warnCount} warning${warnCount === 1 ? "" : "s"}`);
+            const note = noteParts.join(" ");
+            return {
+              status: running ? "up" as const : "down" as const,
+              name: String(svc.name),
+              ...(note ? { note } : {}),
+            };
+          });
+          const overall = checks.some((c) => c.status === "down") ? "warning" as const : "ok" as const;
+
           return {
             status: "ok",
             message: parts.join(", "),
             data,
+            view: contract("status", "Media", { overall, checks }, { source: "hwc_media_status" }),
           };
         } catch (err) {
           return catchError("INTERNAL_ERROR", "Failed to check media status", err, "Are the media containers running?");

--- a/domains/system/mcp/src/src/tools/monitoring.ts
+++ b/domains/system/mcp/src/src/tools/monitoring.ts
@@ -8,6 +8,7 @@ import { listServices } from "../executors/systemd.js";
 import { listContainers } from "../executors/podman.js";
 import { instantQuery, rangeQuery } from "../executors/prometheus.js";
 import { mcpError, catchError } from "../errors.js";
+import { contract } from "../result.js";
 
 interface HealthComponent {
   name: string;
@@ -36,10 +37,17 @@ export async function executeHealthCheck(components?: string[]): Promise<ToolRes
     const hasYellow = result.some((c) => c.status === "yellow");
     const overall = hasRed ? "red" : hasYellow ? "yellow" : "green";
 
+    const mapStatus = (s: string) => (s === "green" ? "ok" : s === "red" ? "error" : "warning");
+    const checks = result.map((c) => ({ status: mapStatus(c.status), name: c.name, note: c.message }));
+
     return {
       status: hasRed ? "partial" : "ok",
       message: `Overall: ${overall} — ${result.length} components checked`,
       data: { overall, components: result },
+      view: contract("status", "Monitoring", {
+        overall: mapStatus(overall),
+        checks,
+      }, { source: "hwc_monitoring", componentCount: result.length }),
     };
   } catch (err) {
     return catchError("INTERNAL_ERROR", "Health check failed", err);

--- a/domains/system/mcp/src/src/tools/network.ts
+++ b/domains/system/mcp/src/src/tools/network.ts
@@ -8,6 +8,7 @@ import type { ToolDef, ToolResult } from "../types.js";
 import { getStatus as getTailscaleStatus } from "../executors/tailscale.js";
 import { TtlCache } from "../cache.js";
 import { mcpError, catchError } from "../errors.js";
+import { contract } from "../result.js";
 
 const cache = new TtlCache();
 
@@ -111,7 +112,34 @@ export function networkTools(runtimeTtl: number, nixosConfigPath?: string): Tool
               }
             }
 
-            return { status: "ok", message: parts.join(", "), data };
+            // Universal Result Contract view (status): one check per tunnel.
+            const checks: Array<{ status: string; name: string; note?: string }> = [];
+            if (data.tailscale) {
+              const ts = data.tailscale as Record<string, unknown>;
+              if (ts.error) {
+                checks.push({ status: "down", name: "tailscale", note: String(ts.error) });
+              } else {
+                const peers = (ts.peers || []) as Array<{ hostname: string; online: boolean }>;
+                const onlineCount = peers.filter((p) => p.online).length;
+                checks.push({ status: "up", name: "tailscale", note: `${onlineCount}/${peers.length} peers online` });
+              }
+            }
+            if (data.vpn) {
+              const vpn = data.vpn as Record<string, unknown>;
+              if (vpn.error) {
+                checks.push({ status: "down", name: "vpn", note: String(vpn.error) });
+              } else {
+                checks.push({ status: "up", name: "vpn", note: "Gluetun reachable" });
+              }
+            }
+            const overall = checks.some((c) => c.status === "down") ? "warning" : "ok";
+
+            return {
+              status: "ok",
+              message: parts.join(", "),
+              data,
+              view: contract("status", "Network", { overall, checks }, { source: "hwc_network", action }),
+            };
           } catch (err) {
             return catchError("UNAVAILABLE", "Failed to get tunnel status", err);
           }
@@ -154,10 +182,15 @@ export function networkTools(runtimeTtl: number, nixosConfigPath?: string): Tool
                   }
                 }
 
+                const source = "admin-api";
                 return {
                   status: "ok",
                   message: `${routes.length} routes across ${Object.keys(servers || {}).length} servers (live)`,
-                  data: { source: "admin-api", routes, serverCount: Object.keys(servers || {}).length },
+                  data: { source, routes, serverCount: Object.keys(servers || {}).length },
+                  view: contract("status", "Network", {
+                    overall: "ok",
+                    checks: [{ status: "up", name: "caddy", note: `${routes.length} routes (${source})` }],
+                  }, { source: "hwc_network", action }),
                 };
               }
             } catch {
@@ -202,7 +235,16 @@ export function networkTools(runtimeTtl: number, nixosConfigPath?: string): Tool
                   return entry;
                 });
 
-                return { status: "ok", message: `${routes.length} routes from routes.nix`, data: { source: "routes.nix", routes: compact } };
+                const source = "routes.nix";
+                return {
+                  status: "ok",
+                  message: `${routes.length} routes from routes.nix`,
+                  data: { source, routes: compact },
+                  view: contract("status", "Network", {
+                    overall: "ok",
+                    checks: [{ status: "ok", name: "caddy", note: `${routes.length} routes (${source})` }],
+                  }, { source: "hwc_network", action }),
+                };
               } catch {
                 // routes.nix not readable
               }

--- a/domains/system/mcp/src/src/tools/services.ts
+++ b/domains/system/mcp/src/src/tools/services.ts
@@ -10,6 +10,7 @@ import { getContainerStats, listContainers } from "../executors/podman.js";
 import { safeExec } from "../executors/shell.js";
 import { TtlCache } from "../cache.js";
 import { mcpError, catchError } from "../errors.js";
+import { contract } from "../result.js";
 
 const cache = new TtlCache();
 
@@ -145,6 +146,19 @@ export function servicesTools(runtimeTtl: number, nixosConfigPath?: string): Too
                 unhealthy,
                 healthy: active.map((s) => s.name),
               },
+              view: contract(
+                "status",
+                "Services",
+                {
+                  overall: failed.length > 0 ? "warning" : "ok",
+                  checks: [
+                    { status: "ok", name: "active", note: `${active.length} running` },
+                    { status: failed.length ? "error" : "ok", name: "failed", note: failed.length ? failed.map((s) => s.name).join(", ") : "none" },
+                    { status: "ok", name: "other", note: `${other.length}` },
+                  ],
+                },
+                { source: "hwc_services" },
+              ),
             };
           } catch (err) {
             return catchError("INTERNAL_ERROR", "Failed to query services", err, "Check that systemctl and podman are accessible");

--- a/domains/system/mcp/src/src/tools/storage.ts
+++ b/domains/system/mcp/src/src/tools/storage.ts
@@ -5,6 +5,7 @@
 import type { ToolDef, ToolResult } from "../types.js";
 import { safeExec } from "../executors/shell.js";
 import { catchError } from "../errors.js";
+import { contract } from "../result.js";
 
 export function storageTools(): ToolDef[] {
   return [
@@ -157,10 +158,70 @@ export function storageTools(): ToolDef[] {
             parts.push(`Backup: ${props.ActiveState || "unknown"}`);
           }
 
+          // Universal Result Contract view (additive).
+          type Check = {
+            status: "ok" | "warning" | "error";
+            name: string;
+            note?: string;
+          };
+          const rank = { ok: 0, warning: 1, error: 2 } as const;
+          const checks: Check[] = [];
+
+          const disk = data.disk as
+            | {
+                mounts: Array<{
+                  mount: string;
+                  size?: string;
+                  used?: string;
+                  percentUsed?: number;
+                  error?: string;
+                }>;
+              }
+            | undefined;
+          if (disk) {
+            for (const m of disk.mounts) {
+              if (m.error) {
+                checks.push({ status: "error", name: m.mount, note: m.error });
+                continue;
+              }
+              const pct = m.percentUsed ?? 0;
+              const cs: Check["status"] =
+                pct > 90 ? "error" : pct > 75 ? "warning" : "ok";
+              const note =
+                m.used && m.size ? `${m.used}/${m.size}` : `${pct}% used`;
+              checks.push({ status: cs, name: m.mount, note });
+            }
+          }
+
+          const backup = data.backup as
+            | { serviceState?: string; exitStatus?: string }
+            | undefined;
+          if (backup) {
+            const failed =
+              backup.serviceState === "failed" ||
+              (backup.exitStatus !== undefined && backup.exitStatus !== "0");
+            checks.push({
+              status: failed ? "error" : "ok",
+              name: "borg backup",
+              note: `service ${backup.serviceState || "unknown"}, exit ${backup.exitStatus ?? "n/a"}`,
+            });
+          }
+
+          const overall = checks.reduce<Check["status"]>(
+            (worst, c) => (rank[c.status] > rank[worst] ? c.status : worst),
+            "ok",
+          );
+
           return {
             status: hasError ? "error" : "ok",
             message: parts.join(", "),
             data,
+            view: contract(
+              "status",
+              "Storage",
+              { overall, checks },
+              { source: "hwc_storage_status" },
+            ),
           };
         } catch (err) {
           return catchError("INTERNAL_ERROR", "Failed to check storage status", err);

--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781615157,
-        "narHash": "sha256-zRZQb0BBjP3bH+F610H1GiI6M2Yu7n8IAKvH/7DWMgo=",
+        "lastModified": 1781622816,
+        "narHash": "sha256-6kEZTjBxcwzvb9DvZUIYfLPpxu5OAn5j60dIZKOaQFI=",
         "ref": "refs/heads/main",
-        "rev": "467e0bbd4aef99e47d604425133ea826f73c484a",
-        "revCount": 7,
+        "rev": "aba0a750c67eb5a7f5f341e82a7456c9c5179d90",
+        "revCount": 8,
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
       },


### PR DESCRIPTION
Builds the **Server hub** (highest daily-value dashboard) and the Result Contract producers it needs.

**Gateway (server-side):** the 6 server-health tools now emit a Universal Result Contract `view` (kind `status`): `hwc_services`, `hwc_storage_status`, `hwc_monitoring`, `hwc_media_status`, `hwc_network` (action=tunnels), `hwc_build_git_status`. Each is `{overall, checks:[{status,name,note}]}` with status ∈ ok/up/degraded/warning/down/error; producer noise lives in `meta`. **Purely additive** — legacy `{status,message,data}` untouched. `tsc` clean.

**Workbench (laptop):** new `hubs/server.toml` (6 status tiles + edit/files/tasks actions) and 6 canonical-shape fixtures, so it renders offline == live. Already live on the laptop via fixtures; goes live once the gateway is deployed.

**Deploy (server, src-only — no nixos-rebuild):** `git pull` on hwc-server, then `cd ~/.nixos/domains/system/mcp/src && npm run build`, then restart the gateway service.

Verified: `tsc --noEmit` exit 0; all 6 tiles load + render through the real loader on fixtures; workbench tests 142 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)