### PR TITLE
feat: powerline tab bar (zjstatus) + workbench host-pane polish

### DIFF
--- a/domains/home/apps/zellij/index.nix
+++ b/domains/home/apps/zellij/index.nix
@@ -16,7 +16,7 @@
 # as `config.hwc.home.theme.colors`; this module derives the zellij theme from
 # it. Switch hwc.home.theme.palette → zellij + workbench restyle on rebuild.
 
-{ config, lib, pkgs, osConfig ? {}, ... }:
+{ config, lib, pkgs, osConfig ? {}, inputs ? {}, ... }:
 
 let
   cfg = config.hwc.home.apps.zellij;
@@ -30,7 +30,18 @@ let
   # assumed local `aerc`. Derived from the single declaration in the shell
   # domain (on the laptop: "ssh -t server aerc"; falls back to "aerc").
   mailCommand = (config.hwc.home.core.shell.aliases or {}).aerc or "aerc";
-  layout      = import ./parts/layout.nix { inherit lib mailCommand; };
+
+  # True-powerline tab bar via the zjstatus plugin (the built-in zellij:tab-bar
+  # can't do powerline segments). Themed from the active palette. Guarded: only
+  # used when cfg.powerlineTabs AND the zjstatus input is present — otherwise the
+  # layout falls back to its built-in tab-bar default, so this is safe even if
+  # the input is removed.
+  zjstatusWasm = lib.optionalString (inputs ? zjstatus)
+    "${inputs.zjstatus.packages.${pkgs.system}.default}/bin/zjstatus.wasm";
+  tabBar = lib.optionalString (cfg.powerlineTabs && inputs ? zjstatus)
+    (import ./parts/zjstatus.nix { inherit lib colors; wasm = zjstatusWasm; });
+  layout = import ./parts/layout.nix
+    ({ inherit lib mailCommand; } // lib.optionalAttrs (tabBar != "") { inherit tabBar; });
 
   # INTER-APP meta layer (Alt+Space). Generated from the unified keymap grammar
   # when it is present (profiles/desktop imports domains/home/keymap). Guarded:
@@ -51,6 +62,16 @@ in
       type = lib.types.str;
       default = "workbench";
       description = "Layout zellij opens by default (the workbench KDL grid).";
+    };
+
+    powerlineTabs = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Use the zjstatus plugin for a themed true-powerline tab bar instead of
+        the built-in zellij:tab-bar. Requires the `zjstatus` flake input; falls
+        back to the built-in bar when off or the input is absent.
+      '';
     };
   };
 

--- a/domains/home/apps/zellij/parts/layout.nix
+++ b/domains/home/apps/zellij/parts/layout.nix
@@ -12,7 +12,7 @@
 # laptop, mail lives on the server, so index.nix derives it from the user's
 # `hwc.home.core.shell.aliases.aerc` (e.g. "ssh -t server aerc"). Split into a
 # KDL command + args node so the suspended pane runs the right thing on <ENTER>.
-{ lib, mailCommand ? "aerc" }:
+{ lib, mailCommand ? "aerc", tabBar ? ''plugin location="zellij:tab-bar";'' }:
 
 let
   # Tab names come from the shared source of truth so the host's WORKBENCH_TABS
@@ -41,7 +41,7 @@ in
         // these a custom layout renders bare panes with no way to discover the
         // other tabs or how to move — `children` is where each tab's panes land.
         default_tab_template {
-            pane size=1 borderless=true { plugin location="zellij:tab-bar"; }
+            pane size=1 borderless=true { ${tabBar} }
             children
             pane size=1 borderless=true { plugin location="zellij:status-bar"; }
         }

--- a/domains/home/apps/zellij/parts/zjstatus.nix
+++ b/domains/home/apps/zellij/parts/zjstatus.nix
@@ -1,0 +1,38 @@
+# domains/home/apps/zellij/parts/zjstatus.nix
+#
+# Pure function: palette colors + wasm path -> a zjstatus plugin KDL block that
+# renders a themed TRUE-POWERLINE tab bar. Drops into the workbench layout's
+# default_tab_template in place of the built-in `zellij:tab-bar` (which can't do
+# powerline segments). Colors are baked from the ACTIVE theme, so the bar
+# restyles on a `hwc.home.theme.palette` switch — same consume-contract as
+# parts/appearance.nix (apps consume the palette, never define it).
+#
+# Look: each tab is a powerline segment ( left-cap …  right-cap) sitting on the
+# bar background; inactive tabs use a muted fill, the active tab pops in `accent`
+# (bold, dark text). Tune the token choices below to taste.
+
+{ lib, colors, wasm }:
+
+let
+  # palette token -> "#rrggbb" (fallback keeps the bar valid if a token is absent)
+  c = name: fallback: "#" + (colors.${name} or fallback);
+  bg0    = c "bg0" "1d2021";   # bar background (matches the host)
+  bg2    = c "bg2" "2c3338";   # inactive segment fill
+  fg2    = c "fg2" "a7aaad";   # inactive segment text
+  accent = c "accent" "d08770"; # active segment fill
+  # Powerline caps (Nerd Font / powerline glyphs):  = U+E0B2 (left),  = U+E0B0 (right)
+  capL = "";
+  capR = "";
+in
+''
+  plugin location="file:${wasm}" {
+      format_left  "{tabs}"
+      format_right ""
+      format_space "#[bg=${bg0}]"
+      hide_frame_for_single_pane "false"
+      // inactive tab: muted segment with powerline caps into the bar bg
+      tab_normal "#[fg=${bg2},bg=${bg0}]${capL}#[fg=${fg2},bg=${bg2}] {name} #[fg=${bg2},bg=${bg0}]${capR}"
+      // active tab: accent segment, bold dark text, same caps
+      tab_active "#[fg=${accent},bg=${bg0}]${capL}#[fg=${bg0},bg=${accent},bold] {name} #[fg=${accent},bg=${bg0}]${capR}"
+  }
+''

--- a/flake.lock
+++ b/flake.lock
@@ -88,6 +88,21 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1776396856,
+        "narHash": "sha256-aRJpIJUlZLaf06ekPvqjuU46zvO9K90IxJGpbqodkPs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "28462d6d55c33206ffa5a56c7907ca3125ed788f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -171,6 +186,24 @@
     "flake-utils_3": {
       "inputs": {
         "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -372,7 +405,8 @@
         "nixpkgs-tailscale": "nixpkgs-tailscale",
         "nixvirt": "nixvirt",
         "todui": "todui",
-        "workbench": "workbench"
+        "workbench": "workbench",
+        "zjstatus": "zjstatus"
       }
     },
     "rust-overlay": {
@@ -388,6 +422,27 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "a1d32c90c8a4ea43e9586b7e5894c179d5747425",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "zjstatus",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776395632,
+        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
         "type": "github"
       },
       "original": {
@@ -471,6 +526,21 @@
         "type": "github"
       }
     },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "todui": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -500,17 +570,40 @@
         ]
       },
       "locked": {
-        "lastModified": 1781622816,
-        "narHash": "sha256-6kEZTjBxcwzvb9DvZUIYfLPpxu5OAn5j60dIZKOaQFI=",
+        "lastModified": 1781624783,
+        "narHash": "sha256-+4wPaxd/hhHpxGI9NVCf/DgAz8uYgoKjvccZTXAA1mo=",
         "ref": "refs/heads/main",
-        "rev": "aba0a750c67eb5a7f5f341e82a7456c9c5179d90",
-        "revCount": 8,
+        "rev": "e68fd605b80a05d341896910c7f8498c9c09bf15",
+        "revCount": 9,
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
       },
       "original": {
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
+      }
+    },
+    "zjstatus": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1780512417,
+        "narHash": "sha256-/LsFGF0BAYdiVVQZ/8vjo6IXuSsYS+ueIWHN47NHEAc=",
+        "owner": "dj95",
+        "repo": "zjstatus",
+        "rev": "17609e498f88e674b846b844b48ad1dc545fddcf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dj95",
+        "repo": "zjstatus",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,15 @@
       url = "git+file:///home/eric/600_apps/workbench";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # zjstatus — themeable zellij status/tab bar plugin (wasm). Gives a true
+    # seamless powerline tab bar (the built-in tab-bar can't); themed from the
+    # palette in domains/home/apps/zellij. Provides packages.<system>.default
+    # = the built zjstatus.wasm.
+    zjstatus = {
+      url = "github:dj95/zjstatus";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   #============================================================================


### PR DESCRIPTION
Visual pass on the workbench, from the screenshots.

**Tab bar — true powerline (zjstatus).** The built-in `zellij:tab-bar` can't render powerline segments, so this adds the **zjstatus** plugin (new flake input) and generates its config from `config.hwc.home.theme.colors` (`parts/zjstatus.nix`) — capped segments, active tab in `accent` (bold/dark), themed so it restyles on a palette switch. Behind `hwc.home.apps.zellij.powerlineTabs` (default on; built-in fallback when off/absent).

**Host pane (workbench input bump):**
- Tiles are raised cards (border + lighter bg + margins); grid spaced down from the hub row.
- Hub row centered, ordered **HWC · DataX · Server** (new `Hub.order`); `default_hub=hwc` still lands on HWC.
- Status `overall` folded into a colored dot on the tile title (no more lone `● ok` row); up/ok checks whose note says "warn" get a yellow dot; friendly per-kind empty states.

Verified: HM builds + activates; `zellij setup --check` clean; workbench tests 152 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)