### PR TITLE
feat: real Turbo-Vision tile drop shadow (offset dark layer)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781630987,
-        "narHash": "sha256-xAjTLz6IuQVcpm8ioDAyRIUYCLs1Y4EADN4LDON1Rww=",
+        "lastModified": 1781632696,
+        "narHash": "sha256-YblBef0Ljv1q3kLoLlrvevlDRDLFfItXiKWU60JJHL8=",
         "ref": "refs/heads/main",
-        "rev": "ea3796bed049cf672cdfa65a981ea33915695fa3",
-        "revCount": 13,
+        "rev": "d8f7b546adf14da28738b7cf09bbc8f60962a581",
+        "revCount": 15,
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
       },


### PR DESCRIPTION
Tiles now get a true offset drop shadow (dark band bottom-right) via a wrapper container + the tile offset up-left — not a border. Clean lighter panel + uniform border on top. Also fixes a mount-timing bug the wrapper exposed (deferred fetch via call_after_refresh). 🤖 Generated with [Claude Code](https://claude.com/claude-code)