### PR TITLE
fix: uniform tile drop shadow (tiles fill equal-height cells)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781632696,
-        "narHash": "sha256-YblBef0Ljv1q3kLoLlrvevlDRDLFfItXiKWU60JJHL8=",
+        "lastModified": 1781634283,
+        "narHash": "sha256-MK/JFfLMS4ZIpv7U4XUuvs+A47F+rQXYfO4W1vgFnlc=",
         "ref": "refs/heads/main",
-        "rev": "d8f7b546adf14da28738b7cf09bbc8f60962a581",
-        "revCount": 15,
+        "rev": "0ab620f598b8686795da4691447c14f3a4b9325f",
+        "revCount": 16,
         "type": "git",
         "url": "file:///home/eric/600_apps/workbench"
       },


### PR DESCRIPTION
The shadow was content-driven (black void under short tiles). Now grid-rows: 1fr + tiles fill their cells minus a fixed right+bottom margin → identical drop shadow on every tile. 🤖 Generated with [Claude Code](https://claude.com/claude-code)